### PR TITLE
Fix livetable

### DIFF
--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -173,7 +173,7 @@ class ScanPlan(XPD):
         self.name = _clean_md_input(name)
         self.type = 'sc'
         self.scan = _clean_md_input(scan_type)
-        self.sc_params = _clean_md_input(scan_params) # sc_parms is a dictionary
+        self.sc_params = scan_params # sc_parms is a dictionary
         
         self._plan_validator()
         

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -69,7 +69,7 @@ def dryrun(sample,scan,**kwargs):
     elif scan.scan == 'tseries':
        collect_time_series_dryrun(scan,parms[0],'pe1c',**kwargs)
     elif scan.scan == 'Tramp':
-       collect_Temp_series(cmdo, parms['startingT'], parms['endingT'],parms['requested_Tstep'], parms['exposure'], 'pe1c', subs, **kwargs)
+        pass
     else:
        print('unrecognized scan type.  Please rerun with a different scan object')
        return


### PR DESCRIPTION
fix over 2016/02/13 - 2016/02/16

This fix brings LiveTable back by specifying `sc_params = scan.md[' sc_params']`.