### PR TITLE
Refactor yaml create

### DIFF
--- a/tests/beamtime_functional_tests.py
+++ b/tests/beamtime_functional_tests.py
@@ -1,0 +1,83 @@
+#UC1
+# user is ready to set up her acquire objects
+# user checks the current bt.list and sees just bt Beamtime object
+# user creates an experiment object by typing new_exp() 
+# program asks the exp name
+# program removes internal and external white-spaces and checks if the experiment exists
+   # if name exists program exits with message "experiment with name %s exists.  If you are trying to update it please use 'edit_exp'"
+   # if it doesn't exist:
+      # create exp uid
+      # show user the existing metada that will be included from the bt object. Say "to change existing metadata for all experiments run edit_bt. To extend metadata just for current experiment ..." (have to think of a good way of doing this)
+      # ask user for exp metadata and set it.
+ # write yaml file. Save bt metadata not directly in the file, but save the bt_name and use this to read the upstream metadata in load_yaml
+ # update yaml_list.yml file that contains the list of yml objects.  This will be returned when bt.list is called, rather than one obtained dynamically. This ensures that objects don't change position in the list.
+ # functional requirements: separate input and functional logic
+ #                          wrap input statements to make them testable
+ #                          try and make easily extendable when adding new required metadata fields
+****************
+# UC2
+# as UC1 but user wants to edit an existing experiment
+   # if doesn't exist, exit telling to run new_exp()
+   # as above, but 
+       # set uid to the same value as it was in the original exp
+       # give existing values as defaults when the questions are asked
+*****************
+# UC3
+# as UC1 and UC2 but for smaple info
+*****************
+# UC4
+# user reequests a list of existing objects.  List returns obj type, obj name and position in list.  List position is immutable
+# first few are standard:  (note, this is the behavior for spec-like workflow, for l-type users....without any setup lusers can type prun(bt.get(1),bt.get(6)))
+    # list[0] is bt
+    # list[1] is ex dummy (contains dummy information)
+    # list[2] is sa dummy (contains dummy info)
+    # list[3] is sc 'ct#s' (where # is the detector frame-time), e.g., 'ct0.1s'
+    # list[4] is sc ct2#s   0.2
+    # list[5] is sc ct4#s   0.4
+    # list[6] is sc ct1.s   
+    # list[7] is sc ct10.s  
+    # list[8] is sc ct30.s 
+    # list[9] is sc ct1.m   1.m and 60.s are equivalent.  Ideally save one scan object for this but allow user to call it either way. 
+    # list[10] is sc ct10.m 
+ *********************************
+# UC5
+#  user wants to remove an object from the list. Types hide_item()
+# on future bt.list() requests, this item is not returned, though it remains in the yaml dir and in the list itself, it is just not shown.
+# one idea for implementation on this is that list.yaml contains a list of tuples [(type,name,hidebool),()] and so on. 
+**********************************
+# UC6
+# user wants to unhide a list item
+# user types unhide_item()
+# program lists hidden item
+# user selects list of hidden items to unhide
+**********************************
+# UC7
+# user wants to run scans, darks, etc.. 
+# user types prun(bt.get(#),bt.get(##)) for sample and scan objects, where # and #$# are the position of the list
+**********************************
+#UC8
+# as UC7 but user is lazy and only wants to type prun(#,##) where # and ## are integers
+**********************************
+# UC9
+# as UC7 user has a good memory for names, so user would rather type prun('samplename','scanname'), e.g., prun('dummy','ct1.0')
+**********************************
+# UC10
+# as UC10 but user can type any combination of objects, ints or strings
+***********************************
+# Functional requirement:
+# remove the delete object functionality.  We never will delete objects now, just hide them.
+**********************************
+#UC11
+# user wants to do a run prun('mysample','ct75.5') but 75.5 doesn't exist
+# program says 'scan ct75.5s doesnt exist, do you want to create it now [y],n?
+# on '',y' or 'Y' create that scan then run it.
+**********************************
+# UC12
+# as UC11, but the scan exists, the sample doesn't.
+# program exits with a kind message to please create that sample object and retry
+**********************************
+# UC13
+# this should have been higher up, but make new_scan(type,name='') function that helps the user to create scan objects
+# allowed types are currently ct, tserires, Tramp
+# if name is recognizable, create the scan object immediately
+# if the name is ambiguous, ask questions

--- a/tests/beamtime_functional_tests.py
+++ b/tests/beamtime_functional_tests.py
@@ -2,6 +2,7 @@
 # user is ready to set up her acquire objects
 # user checks the current bt.list and sees just bt Beamtime object
 # user creates an experiment object by typing new_exp() 
+  simon working on this
 # program asks the exp name
 # program removes internal and external white-spaces and checks if the experiment exists
    # if name exists program exits with message "experiment with name %s exists.  If you are trying to update it please use 'edit_exp'"

--- a/tests/config_base/yml/bt_bt.yml
+++ b/tests/config_base/yml/bt_bt.yml
@@ -1,0 +1,14 @@
+!!python/object:xpdacq.beamtime.Beamtime
+_base_path: C:\Users\billinge\Documents\GitHub\xpdAcq\tests
+md:
+  bt_experimenters:
+  - !!python/tuple [Banerjee, Soham, 1]
+  - !!python/tuple ['Terban ', ' Max', 2]
+  bt_piLast: Billinge
+  bt_safN: 123.67
+  bt_uid: e571129a-d9a4-11e5-b444-28b2bd4521c0
+  bt_usermd: {}
+  bt_wavelength: 0.1812
+name: bt
+type: bt
+yaml_dir_path: C:\Users\billinge\Documents\GitHub\xpdAcq\tests\config_base\yml

--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -1,0 +1,32 @@
+import unittest
+import os
+import shutil
+from xpdacq.beamtimeSetup import _make_clean_env,_start_beamtime,_end_beamtime,_execute_start_beamtime,_check_empty_environment
+import xpdacq.beamtimeSetup as bts
+
+class NewExptTest(unittest.TestCase): 
+
+    def setUp(self):
+        self.base_dir = os.getcwd()
+        self.home_dir = os.path.join(self.base_dir,'xpdUser')
+        self.PI_name = 'Billinge'
+        self.saf_num = 123.67
+        self.wavelength = 0.1812
+        self.experimenters = [('Banerjee','Soham',1),('Terban ',' Max',2)]
+        os.mkdir(self.home_dir)
+        self.bt = _execute_start_beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters,home_dir=self.home_dir)
+
+
+    def tearDown(self):
+        os.chdir(self.base_dir)
+        self.config_dir = os.path.join(self.base_dir,'xpdConfig')
+        if os.path.isdir(self.home_dir):
+            shutil.rmtree(self.home_dir)
+        if os.path.isdir(self.config_dir):
+            shutil.rmtree(self.config_dir)
+
+    def test_new_exp(self):
+    	self.yaml_dir = os.path.join(self.home_dir,'config_base','yml')
+    	self.assertIsInstance(self.bt,bts.Beamtime)
+    	self.assertTrue(os.path.exists(self.yaml_dir))
+    	#self.fail('need a test')

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -24,10 +24,7 @@ from xpdacq.config import DataPath
 
 
 class XPD:
-    _base_path = ''
-    if not _base_path:
-        dp = DataPath(os.path.expanduser('~'))
-        _base_path = dp.base
+
     def _getuid(self):
         return str(uuid.uuid1())
 
@@ -35,15 +32,15 @@ class XPD:
         return self.md
     
     def _yaml_path(self):
-        yaml_dir_path = os.path.join(self._base_path, 'config_base', 'yml')
-        os.makedirs(yaml_dir_path, exist_ok = True) 
-        return yaml_dir_path
+        self.yaml_dir_path = os.path.join(self._base_path, 'config_base', 'yml')
+        os.makedirs(self.yaml_dir_path, exist_ok = True) 
+        return self.yaml_dir_path
 
     def _yaml_garage_path(self):
-        yaml_garage_dir_path = os.path.join(self._base_path, 'config_base', 'yml_garage')
-        os.makedirs(yaml_garage_dir_path, exist_ok = True)
+        self.yaml_garage_dir_path = os.path.join(self._base_path, 'config_base', 'yml_garage')
+        os.makedirs(self.yaml_garage_dir_path, exist_ok = True)
         # backup directory when user wants to move out objects from default reading list
-        return yaml_garage_dir_path
+        return self.yaml_garage_dir_path
 
                     
     def _yamify(self):
@@ -59,7 +56,7 @@ class XPD:
 
     @classmethod
     def _get_ymls(cls):
-        fpath = cls._yaml_path
+        fpath = cls._yaml_path(cls)
         yamls = os.listdir(fpath)
         return yamls
 
@@ -113,7 +110,12 @@ class XPD:
             return
     
 class Beamtime(XPD):
-    def __init__(self, pi_last, safn, wavelength, experimenters = [], **kwargs):
+    def __init__(self, pi_last, safn, wavelength, experimenters = [], base_dir=None,**kwargs):
+        if not base_dir:
+            dp = DataPath(os.path.expanduser('~'))
+            self._base_path = dp.base
+        else:
+            self._base_path = base_dir
         self.name = 'bt'
         self.type = 'bt'
         self.md = {'bt_piLast': _clean_md_input(pi_last), 'bt_safN': _clean_md_input(safn), 
@@ -122,6 +124,7 @@ class Beamtime(XPD):
         self.md.update({'bt_experimenters': _clean_md_input(experimenters)})
         self.md.update({'bt_uid': self._getuid()})
         self._yamify()
+
 
 class Experiment(XPD):
     def __init__(self, expname, beamtime, **kwargs):
@@ -406,4 +409,10 @@ def _clean_md_input(obj):
         return obj
 
 
-    
+def new_exp():
+
+    return _execute_new_exp()
+
+def _execute_new_exp(expnam,btobj):
+    pass
+

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -195,7 +195,7 @@ def _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None,):
     experimenters = explist
     _make_clean_env(dp)
     os.chdir(dp.base)
-    bt = Beamtime(PI_name,saf_num,wavelength,experimenters)
+    bt = Beamtime(PI_name,saf_num,wavelength,experimenters,base_dir=base_dir)
     return bt
 
 

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -121,9 +121,13 @@ def _execute_end_beamtime(piname,safn,btuid,base_dir,archive_dir,bto):
     shutil.copyfile(tar_ball, archive_f_name) # remote archive'
     return archive_f_name
 
+#def  _get_user_confirmation(text):
+#    input()
+#"Please confirm data are backed up. Are you ready to continue with xpdUser directory contents deletion (y,[n])?: "
 def _confirm_archive():
     print("tarball archived to {}".format(archive_f_name))
-    conf = input("Please confirm data are backed up. Are you ready to continue with xpdUser directory contents deletion (y,[n])?: ")
+#    conf = _any_input_method(input)
+#  can't remember how to do this.....
     if conf in ('y','Y'):
         return
     else:

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -121,17 +121,17 @@ def _execute_end_beamtime(piname,safn,btuid,base_dir,archive_dir,bto):
     shutil.copyfile(tar_ball, archive_f_name) # remote archive'
     return archive_f_name
 
-#def  _get_user_confirmation(text):
-#    input()
-#"Please confirm data are backed up. Are you ready to continue with xpdUser directory contents deletion (y,[n])?: "
+def  _get_user_confirmation():
+    conf = input("Please confirm data are backed up. Are you ready to continue with xpdUser directory contents deletion (y,[n])?: ")
+    return conf
+
 def _confirm_archive():
     print("tarball archived to {}".format(archive_f_name))
-#    conf = _any_input_method(input)
-#  can't remember how to do this.....
+    conf = _any_input_method(_get_user_confirmation)
     if conf in ('y','Y'):
         return
     else:
-        raise RuntimeError('xpdUser directory delete operation cancelled')
+        raise RuntimeError('xpdUser directory delete operation cancelled at Users request')
 
 def _delete_home_dir_tree(base_dir,archive_f_name,bto):
     dp = DataPath(base_dir)


### PR DESCRIPTION
These are the functional tests that I want to work for the refactored create-yaml behavior.

This addresses the issues of persistence (metadata is loaded from yml at run-time not at instantiation time), and the request from users that the position of an object in the list is immutable, and there is a luser mode for l-type users who are used to spec. There are also some other refinements to the behavior.

There is no code or unittests yet, just the functional_tests that define the behavior.

My thoughts on the design are:
 - object list is created as a yaml file and appended when new objects are created.  bt.list returns this list, it doesn't generate a list with os.listdir().
 - get rid of the delete_obj functionality and change it to hide_obj, then tag list items as hidden or not.
 - inside the downstream yamls we don't save the metadata to the upstream yamls, but we save a reference to the upstream yaml file
 - when the downstream yaml is used in any way, it retrieves the metadata in the upsteam yaml file.
 - make helper functions for creating acquire objects so the user is not exposed to the python syntax for instantiating an object.  This also gets rid of the bug that we were accidentally reassigning existing object instances to new objects.  These objects will not be directly accessible to users.