### PR TITLE
fist attmpt to clean B_DIR and other objects

### DIFF
--- a/xpdConfig/999-load.py
+++ b/xpdConfig/999-load.py
@@ -135,7 +135,7 @@ class DataPath(object):
 hostname = socket.gethostname()
 if hostname == 'xf28id1-ws2':
     # real experiment
-    B_DIR = os.path.expanduser('~/')
+    B_DIR = os.path.expanduser('~/pe2_data')
     _bdir(B_DIR)
     dp = DataPath(B_DIR) 
     # TODO - haven't fully cleaned dp yet, but will refactor later
@@ -158,7 +158,7 @@ print('Initializing the XPD data acquisition simulation environment')
 os.chdir(os.path.join(B_DIR, HOME_DIR))
 
 #if there is a yml file in the normal place, then load the beamtime object
-#if len(XPD.loadyamls()) > 0:  --> this will create extra directory 
+#if len(XPD.loadyamls()) > 0: try alternative logic, load in yaml only if yaml_dir exists
 if os.path.isdir(dp.yaml_dir):
     bt = XPD.loadyamls()[0]
 

--- a/xpdConfig/999-load.py
+++ b/xpdConfig/999-load.py
@@ -18,15 +18,15 @@
 
 import os
 import socket
-from xpdacq.xpdacq import _areaDET
-from xpdacq.xpdacq import _tempController
-from xpdacq.xpdacq import _shutter
-from xpdacq.xpdacq import _bdir
+from xpdacq.object_manage import _areaDET
+from xpdacq.object_manage import _tempController
+from xpdacq.object_manage import _shutter
+from xpdacq.object_manage import _bdir
 
 ''' not ready yet
-from xpdacq.xpdacq import _db
-from xpdacq.xpdacq import _getEvents
-from xpdacq.xpdacq import _getImages
+from xpdacq.object_manage import _db
+from xpdacq.object_manage import _getEvents
+from xpdacq.object_manage import _getImages
 '''
 
 import bluesky

--- a/xpdConfig/999-load.py
+++ b/xpdConfig/999-load.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#!/usr/bin/env python
 ##############################################################################
 #
 # xpdacq            by Billinge Group
@@ -14,19 +13,39 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-'''Constants and other global definitions.
+'''Configuration of python object and gloabal constents
 '''
 
-import os.path
-import xpdacq.xpdacq as main
+import os
+import socket
+from xpdacq.xpdacq import _areaDET
+from xpdacq.xpdacq import _tempController
+from xpdacq.xpdacq import _shutter
+from xpdacq.xpdacq import _bdir
 
-B_DIR = main.B_DIR
+''' not ready yet
+from xpdacq.xpdacq import _db
+from xpdacq.xpdacq import _getEvents
+from xpdacq.xpdacq import _getImages
+'''
+
+import bluesky
+from bluesky.run_engine import RunEngine
+
+# instanciate RE:
+# imports in this block can be moved up after making sure it is working
+xpdRE = RunEngine()
+xpdRE.md['owner'] = 'xf28id1'
+xpdRE.md['beamline_id'] = 'xpd'
+xpdRE.md['group'] = 'XPD'
+
 HOME_DIR = 'xpdUser'
 CONFIG_DIR = 'xpdConfig'
+XPD_HOST_NAME = 'xf28id1-ws2'
 
+# Note:
 # base = B_DIR = dp.base = '~'
 # home = HOME_DIR = dp.home = 'xpdUser'
-
 
 class DataPath(object):
     '''Absolute paths to data folders in XPD experiment.
@@ -110,3 +129,38 @@ class DataPath(object):
     def __repr__(self):
         return 'DataPath({!r})'.format(self.stem)
 
+# differentiate simulation or reall experiment based on hostname
+# this method might be refactored soon
+
+hostname = socket.gethostname()
+if hostname == 'xf28id1-ws2':
+    # real experiment
+    B_DIR = os.path.expanduser('~/')
+    _bdir(B_DIR)
+    dp = DataPath(B_DIR) 
+    # TODO - haven't fully cleaned dp yet, but will refactor later
+    bluesky.register_mds.register_mds(xpdRE)
+
+
+else:
+    print('==== Simulation ====')
+    B_DIR = os.getcwd()
+    _bdir(B_DIR)
+    dp = DataPath(B_DIR)
+
+# can't top import as objects are just created above
+from xpdacq.beamtimeSetup import _start_beamtime, _end_beamtime
+from xpdacq.beamtime import XPD
+# FIXME - extra directories are created when importing certain function, which leads logic loop hole in start_beamtime
+# XPD creates config_base/yml and export_data() creates Exports/
+
+print('Initializing the XPD data acquisition simulation environment') 
+os.chdir(os.path.join(B_DIR, HOME_DIR))
+
+#if there is a yml file in the normal place, then load the beamtime object
+#if len(XPD.loadyamls()) > 0:  --> this will create extra directory 
+if os.path.isdir(dp.yaml_dir):
+    bt = XPD.loadyamls()[0]
+
+print('OK, ready to go.  To continue, follow the steps in the xpdAcq')
+print('documentation at http://xpdacq.github.io/xpdacq')

--- a/xpd_profile_file/999-load.py
+++ b/xpd_profile_file/999-load.py
@@ -135,7 +135,7 @@ class DataPath(object):
 hostname = socket.gethostname()
 if hostname == 'xf28id1-ws2':
     # real experiment
-    B_DIR = os.path.expanduser('~/')
+    B_DIR = os.path.expanduser('~/pe2_data')
     _bdir(B_DIR)
     dp = DataPath(B_DIR) 
     # TODO - haven't fully cleaned dp yet, but will refactor later
@@ -158,7 +158,7 @@ print('Initializing the XPD data acquisition simulation environment')
 os.chdir(os.path.join(B_DIR, HOME_DIR))
 
 #if there is a yml file in the normal place, then load the beamtime object
-#if len(XPD.loadyamls()) > 0:  --> this will create extra directory 
+#if len(XPD.loadyamls()) > 0: try alternative logic, load in yaml only if yaml_dir exists
 if os.path.isdir(dp.yaml_dir):
     bt = XPD.loadyamls()[0]
 

--- a/xpd_profile_file/999-load.py
+++ b/xpd_profile_file/999-load.py
@@ -18,15 +18,15 @@
 
 import os
 import socket
-from xpdacq.xpdacq import _areaDET
-from xpdacq.xpdacq import _tempController
-from xpdacq.xpdacq import _shutter
-from xpdacq.xpdacq import _bdir
+from xpdacq.object_manage import _areaDET
+from xpdacq.object_manage import _tempController
+from xpdacq.object_manage import _shutter
+from xpdacq.object_manage import _bdir
 
 ''' not ready yet
-from xpdacq.xpdacq import _db
-from xpdacq.xpdacq import _getEvents
-from xpdacq.xpdacq import _getImages
+from xpdacq.object_manage import _db
+from xpdacq.object_manage import _getEvents
+from xpdacq.object_manage import _getImages
 '''
 
 import bluesky

--- a/xpd_profile_file/999-load.py
+++ b/xpd_profile_file/999-load.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#!/usr/bin/env python
 ##############################################################################
 #
 # xpdacq            by Billinge Group
@@ -14,19 +13,39 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-'''Constants and other global definitions.
+'''Configuration of python object and gloabal constents
 '''
 
-import os.path
-import xpdacq.xpdacq as main
+import os
+import socket
+from xpdacq.xpdacq import _areaDET
+from xpdacq.xpdacq import _tempController
+from xpdacq.xpdacq import _shutter
+from xpdacq.xpdacq import _bdir
 
-B_DIR = main.B_DIR
+''' not ready yet
+from xpdacq.xpdacq import _db
+from xpdacq.xpdacq import _getEvents
+from xpdacq.xpdacq import _getImages
+'''
+
+import bluesky
+from bluesky.run_engine import RunEngine
+
+# instanciate RE:
+# imports in this block can be moved up after making sure it is working
+xpdRE = RunEngine()
+xpdRE.md['owner'] = 'xf28id1'
+xpdRE.md['beamline_id'] = 'xpd'
+xpdRE.md['group'] = 'XPD'
+
 HOME_DIR = 'xpdUser'
 CONFIG_DIR = 'xpdConfig'
+XPD_HOST_NAME = 'xf28id1-ws2'
 
+# Note:
 # base = B_DIR = dp.base = '~'
 # home = HOME_DIR = dp.home = 'xpdUser'
-
 
 class DataPath(object):
     '''Absolute paths to data folders in XPD experiment.
@@ -110,3 +129,38 @@ class DataPath(object):
     def __repr__(self):
         return 'DataPath({!r})'.format(self.stem)
 
+# differentiate simulation or reall experiment based on hostname
+# this method might be refactored soon
+
+hostname = socket.gethostname()
+if hostname == 'xf28id1-ws2':
+    # real experiment
+    B_DIR = os.path.expanduser('~/')
+    _bdir(B_DIR)
+    dp = DataPath(B_DIR) 
+    # TODO - haven't fully cleaned dp yet, but will refactor later
+    bluesky.register_mds.register_mds(xpdRE)
+
+
+else:
+    print('==== Simulation ====')
+    B_DIR = os.getcwd()
+    _bdir(B_DIR)
+    dp = DataPath(B_DIR)
+
+# can't top import as objects are just created above
+from xpdacq.beamtimeSetup import _start_beamtime, _end_beamtime
+from xpdacq.beamtime import XPD
+# FIXME - extra directories are created when importing certain function, which leads logic loop hole in start_beamtime
+# XPD creates config_base/yml and export_data() creates Exports/
+
+print('Initializing the XPD data acquisition simulation environment') 
+os.chdir(os.path.join(B_DIR, HOME_DIR))
+
+#if there is a yml file in the normal place, then load the beamtime object
+#if len(XPD.loadyamls()) > 0:  --> this will create extra directory 
+if os.path.isdir(dp.yaml_dir):
+    bt = XPD.loadyamls()[0]
+
+print('OK, ready to go.  To continue, follow the steps in the xpdAcq')
+print('documentation at http://xpdacq.github.io/xpdacq')

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -42,15 +42,18 @@ class XPD:
         return self.md
 
     def _yaml_path(self):
-        yaml_dir_path = os.path.join(self._home_path, 'config_base', 'yml')
-        os.makedirs(yaml_dir_path, exist_ok = True)
-        return yaml_dir_path
+        self.yaml_dir_path = os.path.join(self._home_path, 'config_base', 'yml')
+        #os.makedirs(yaml_dir_path, exist_ok = True)
+        return self.yaml_dir_path
+
+    def _make_dirs(self, path_to_create):
+        os.makedirs(path_to_create, exist_ok = True)
 
     def _yaml_garage_path(self):
-        yaml_garage_dir_path = os.path.join(self._home_path, 'config_base', 'yml_garage')
+        self.yaml_garage_dir_path = os.path.join(self._home_path, 'config_base', 'yml_garage')
         # backup directory when user wants to move out objects from default reading list
-        os.makedirs(yaml_garage_dir_path, exist_ok = True)
-        return yaml_garage_dir_path
+        #os.makedirs(yaml_garage_dir_path, exist_ok = True)
+        return self.yaml_garage_dir_path
 
     def _yamify(self):
         '''write a yaml file for this object and place it in config_base/yml'''
@@ -66,12 +69,14 @@ class XPD:
     @classmethod
     def _get_ymls(cls):
         fpath = cls._yaml_path
+        cls._make_dirs(cls,fpath) # Tim test
         yamls = os.listdir(fpath)
         return yamls
 
     @classmethod
     def loadyamls(cls):
         fpath = cls._yaml_path(cls)
+        cls._make_dirs(cls,fpath) # Tim test
         yamls = os.listdir(fpath)
         olist = []
         for f in yamls:

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -22,7 +22,7 @@ from time import strftime
 import sys
 
 from xpdacq.config import DataPath
-import xpdacq.xpdacq as main
+import xpdacq.object_manage as main
 B_DIR = main.B_DIR
 print('heyyyy B_DIR= {}'.format(B_DIR))
 

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -20,32 +20,38 @@ import shutil
 import datetime
 from time import strftime
 import sys
+
 from xpdacq.config import DataPath
+import xpdacq.xpdacq as main
+B_DIR = main.B_DIR
+print('heyyyy B_DIR= {}'.format(B_DIR))
 
 
 class XPD:
-    _base_path = ''
-    if not _base_path:
-        dp = DataPath(os.path.expanduser('~'))
-        _base_path = dp.base
+    #_base_path = ''
+    #if not _base_path:
+        #dp = DataPath(os.path.expanduser('~'))
+        #_base_path = dp.base
+    dp = DataPath(B_DIR)
+    _home_path = dp.home
+
     def _getuid(self):
         return str(uuid.uuid1())
 
     def export(self):
         return self.md
-    
+
     def _yaml_path(self):
-        yaml_dir_path = os.path.join(self._base_path, 'config_base', 'yml')
-        os.makedirs(yaml_dir_path, exist_ok = True) 
+        yaml_dir_path = os.path.join(self._home_path, 'config_base', 'yml')
+        os.makedirs(yaml_dir_path, exist_ok = True)
         return yaml_dir_path
 
     def _yaml_garage_path(self):
-        yaml_garage_dir_path = os.path.join(self._base_path, 'config_base', 'yml_garage')
-        os.makedirs(yaml_garage_dir_path, exist_ok = True)
+        yaml_garage_dir_path = os.path.join(self._home_path, 'config_base', 'yml_garage')
         # backup directory when user wants to move out objects from default reading list
+        os.makedirs(yaml_garage_dir_path, exist_ok = True)
         return yaml_garage_dir_path
 
-                    
     def _yamify(self):
         '''write a yaml file for this object and place it in config_base/yml'''
         fname = self.name
@@ -250,77 +256,6 @@ class ScanPlan(XPD):
             print('Please use uparrow to edit and retry making your ScanPlan object')
             sys.exit('Please ignore this RunTime error and continue, using the hint above if you like')
 
-        ''' bad logic, will be discarded
-        if self.scan == 'ct':
-            if list(self.sc_params.keys()) == _ct_required_params:
-                pass
-            else:
-                extra_sc_params = list()
-                for el in list(self.sc_params.keys()):
-                    if el not in _ct_required_params:
-                        extra_sc_params.append(el)
-                if extra_sc_params:
-                    print('It seems you are using a Count scan but the scan_params dictionary contain extra parameters {}'.format(extra_sc_params))
-
-                required_sc_params = list()
-                for el in _ct_required_params:
-                    try:
-                        self.sc_params[el]
-                    except KeyError:
-                        required_sc_params.append(el)
-                if required_sc_params:
-                    print('It seems you are using a Count scan but the scan_params dictionary doesn not contain {} which is needed'.format(required_sc_params))
-                
-                print('Please use uparrow to edit and retry making your ScanPlan object')
-                sys.exit('Please ignore this RunTime error and continue, using the hint above if you like')
-
-        elif self.scan == 'Tramp':
-            if list(self.sc_params.keys()) == _Tramp_required_params:
-                pass
-            else:
-                extra_sc_params = list()
-                for el in list(self.sc_params.keys()):
-                    if el not in _Tramp_required_params:
-                        extra_sc_params.append(el)
-                if extra_sc_params:
-                    print('It seems you are using a Tramp scan but the scan_params dictionary contain extra parameters {}'.format(extra_sc_params))
-
-                required_sc_params = list()
-                for el in _Tramp_required_params:
-                    try:
-                        self.sc_params[el]
-                    except KeyError:
-                        required_sc_params.append(el)
-                if required_sc_params:
-                    print('It seems you are using a Tramp scan but the scan_params dictionary doesn not contain {} which is needed'.format(required_sc_params))
-                
-                print('Please use uparrow to edit and retry making your ScanPlan object')
-                sys.exit('Please ignore this RunTime error and continue, using the hint above if you like')
-                   
-        elif self.scan == 'tseries':
-            if list(self.sc_params.keys()) == _tseries_required_params:
-                pass
-            else:
-                extra_sc_params = list()
-                for el in list(self.sc_params.keys()):
-                    if el not in _tseries_required_params:
-                        extra_sc_params.append(el)
-                if extra_sc_params:
-                    print('It seems you are using a tseries scan but the scan_params dictionary contain extra parameters {}'.format(extra_sc_params))
-
-                required_sc_params = list()
-                for el in _tseries_required_params:
-                    try:
-                        self.sc_params[el]
-                    except KeyError:
-                        required_sc_params.append(el)
-                if required_sc_params:
-                    print('It seems you are using a tseries scan but the scan_params dictionary doesn not contain {} which is needed'.format(required_sc_params))
-                
-                print('Please use uparrow to edit and retry making your ScanPlan object')
-                sys.exit('Please ignore this RunTime error and continue, using the hint above if you like')
-        '''
-        
 
 class Union(XPD):
     def __init__(self,sample,scan):
@@ -350,7 +285,7 @@ def export_data(root_dir=None, ar_format='gztar', end_beamtime=False):
 
     """
     # FIXME - test purpose
-    B_DIR = os.path.expanduser('~')
+    #B_DIR = os.path.expanduser('~')
     if root_dir is None:
         root_dir = B_DIR
     dp = DataPath(root_dir)

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -178,8 +178,9 @@ def _start_beamtime(base_dir=None):
     explist = list(input('default = []  '))
     if explist == '':
         explist = []
+    #return _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None)
     return _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None)
-
+ 
 def _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None):
     if base_dir is None:
         base_dir = B_DIR

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -18,20 +18,15 @@ import os
 import datetime
 import shutil
 from time import strftime
+import xpdacq.xpdacq as main
 from xpdacq.config import DataPath
 from xpdacq.beamtime import Beamtime, XPD
 from xpdacq.beamtime import export_data
-#from xpdacq.control import _get_obj
 
-B_DIR = os.path.expanduser('~')
-#def _get_obj(name):
-    #ip = get_ipython() # build-in function
-    #return ip.user_ns[name]
+B_DIR = main.B_DIR
+dp = DataPath(B_DIR)
 
-#B_DIR = _get_obj('B_DIR')
-
-
-# just a note. Assign by Sanjit
+# just a note. Assigned by Sanjit
 REMOTE_DIR = os.path.expanduser('~/pe2_data/')
 BACKUP_DIR = os.path.join(REMOTE_DIR, strftime('%Y'), 'userBeamtimeArchive')
 
@@ -74,8 +69,8 @@ def _end_beamtime(base_dir=None,archive_dir=None,bto=None):
                       # FIXME - load_yaml directly ?
         except NameError:
             bto = {}              # FIXME, temporary hack. Remove when we have object imports working properly
-    dp = DataPath(base_dir)
-    files = os.listdir(dp.base)
+    #dp = DataPath(base_dir)
+    files = os.listdir(dp.home)
     if len(files)==1:
         print('It appears that end_beamtime may have been run.  If so, do not run again but proceed to _start_beamtime')
         return
@@ -136,11 +131,11 @@ def _confirm_archive(archive_f_name):
 def _delete_home_dir_tree(base_dir, archive_f_name, bto):
     dp = DataPath(base_dir)
     os.chdir(dp.stem)   # don't remember the name, but move up one directory out of xpdUser before deleting it!
-    shutil.rmtree(dp.base)
-    os.makedirs(dp.base, exist_ok=True)
-    shutil.copy(archive_f_name, dp.base)
-    os.chdir(dp.base)   # now move back into xpdUser so everyone is not confused....
-    final_path = os.path.join(dp.base, os.path.basename(archive_f_name)) # local archive
+    shutil.rmtree(dp.home)
+    os.makedirs(dp.home, exist_ok=True)
+    shutil.copy(archive_f_name, dp.home)
+    os.chdir(dp.home)   # now move back into xpdUser so everyone is not confused....
+    final_path = os.path.join(dp.home, os.path.basename(archive_f_name)) # local archive
     #print("Final archive file at {}".format(final_path))
     return 'local copy of tarball for user: '+final_path
 
@@ -155,21 +150,21 @@ def _check_empty_environment(base_dir=None):
     if base_dir is None:
         base_dir = B_DIR
     dp = DataPath(base_dir)
-    if os.path.exists(dp.base):
-        if not os.path.isdir(dp.base):
+    if os.path.exists(dp.home):
+        if not os.path.isdir(dp.home):
             raise RuntimeError("Expected a folder, got a file.  "
                                "Please Talk to beamline staff")
-        files = os.listdir(dp.base) # that also list dirs that have been created
+        files = os.listdir(dp.home) # that also list dirs that have been created
         if len(files) > 1:
             #print(len(files))
-            raise RuntimeError("Unexpected files in {}, you need to run _end_beamtime(). Please Talk to beamline staff".format(dp.base))
+            raise RuntimeError("Unexpected files in {}, you need to run _end_beamtime(). Please Talk to beamline staff".format(dp.home))
         elif len(files) == 1:
             tf, = files
             if 'tar' not in tf:
                 raise RuntimeError("Expected a tarball of some sort, found {} "
                                    "Please talk to beamline staff"
                                    .format(tf))
-            os.unlink(os.path.join(dp.base, tf))
+            os.unlink(os.path.join(dp.home, tf))
     else:
         raise RuntimeError("The xpdUser directory appears not to exist "
                                "Please Talk to beamline staff")
@@ -183,9 +178,9 @@ def _start_beamtime(base_dir=None):
     explist = list(input('default = []  '))
     if explist == '':
         explist = []
-    return _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None,)
+    return _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None)
 
-def _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None,):
+def _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None):
     if base_dir is None:
         base_dir = B_DIR
     dp = DataPath(base_dir)
@@ -194,7 +189,7 @@ def _execute_start_beamtime(piname,safn,wavelength,explist,base_dir=None,):
     wavelength = wavelength
     experimenters = explist
     _make_clean_env(dp)
-    os.chdir(dp.base)
+    os.chdir(dp.home)
     bt = Beamtime(PI_name,saf_num,wavelength,experimenters)
     return bt
 

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -18,7 +18,7 @@ import os
 import datetime
 import shutil
 from time import strftime
-import xpdacq.xpdacq as main
+import xpdacq.object_manage as main
 from xpdacq.config import DataPath
 from xpdacq.beamtime import Beamtime, XPD
 from xpdacq.beamtime import export_data

--- a/xpdacq/config.py
+++ b/xpdacq/config.py
@@ -18,7 +18,7 @@
 '''
 
 import os.path
-import xpdacq.xpdacq as main
+import xpdacq.object_manage as main
 
 B_DIR = main.B_DIR
 HOME_DIR = 'xpdUser'

--- a/xpdacq/object_manage.py
+++ b/xpdacq/object_manage.py
@@ -1,0 +1,38 @@
+##############################################################################
+#
+# xpdacq            by Billinge Group
+#                   Simon J. L. Billinge sb2896@columbia.edu
+#                   (c) 2016 trustees of Columbia University in the City of
+#                        New York.
+#                   All rights reserved
+#
+# File coded by:    Timothy Liu, Simon Billinge
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+#
+##############################################################################
+
+def _areaDET(area_det_name):
+    global AREA_DET
+    AREA_DET = area_det_name
+
+def _tempController(temp_controller_name):
+    global TEMP_CONTROLLER
+    TEMP_CONTROLLER = temp_controller_name
+
+def _shutter(shutter_name):
+    global SHUTTER
+    SHUTTER = shutter_name
+
+def _bdir(b_dir_name):
+    global B_DIR
+    B_DIR = b_dir_name
+
+# analysis objects : not ready yet
+# db
+# LiveTable
+# get_events
+# get_images
+

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -15,14 +15,16 @@
 #
 ##############################################################################
 import numpy as np
-#from xpdacq.beamtime import Union, Xposure
+from xpdacq.beamtime import Union, Xposure
 from bluesky.plans import Count
 from bluesky import Msg
-#from xpdacq.control import _get_obj   
 #from xpdacq.control import _open_shutter
 #from xpdacq.control import _close_shutter
-#from xpdacq.analysis import *
 from bluesky.plans import AbsScanPlan
+
+import xpdacq.object_manage as main
+B_DIR = main.B_DIR
+print('B_DIR from xpdacq.py {}'.format(B_DIR))
 
 ''' things that should be created and imported during start_up
 #xpdRE = _get_obj('xpdRE')
@@ -39,27 +41,6 @@ from bluesky.plans import AbsScanPlan
 print('Before you start, make sure the area detector IOC is in "Acquire mode"')
 #expo_threshold = 60 # in seconds Deprecated!
 
-def _areaDET(area_det_name):
-    global AREA_DET
-    AREA_DET = area_det_name
-
-def _tempController(temp_controller_name):
-    global TEMP_CONTROLLER
-    TEMP_CONTROLLER = temp_controller_name
-
-def _shutter(shutter_name):
-    global SHUTTER
-    SHUTTER = shutter_name
-
-def _bdir(b_dir_name):
-    global B_DIR
-    B_DIR = b_dir_name
-
-# analysis objects : not ready yet
-# db
-# LiveTable
-# get_events
-# get_images
 
 def dryrun(sample,scan,**kwargs):
     '''same as run but scans are not executed.

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -14,35 +14,52 @@
 #
 #
 ##############################################################################
-def _get_obj(name):
-    ip = get_ipython() # build-in function
-    return ip.user_ns[name]
-
 import numpy as np
-from xpdacq.beamtime import Union, Xposure
+#from xpdacq.beamtime import Union, Xposure
 from bluesky.plans import Count
 from bluesky import Msg
-from xpdacq.control import _get_obj   
-from xpdacq.control import _open_shutter
-from xpdacq.control import _close_shutter
-from xpdacq.analysis import *
+#from xpdacq.control import _get_obj   
+#from xpdacq.control import _open_shutter
+#from xpdacq.control import _close_shutter
+#from xpdacq.analysis import *
 from bluesky.plans import AbsScanPlan
 
-xpdRE = _get_obj('xpdRE')
-LiveTable = _get_obj('LiveTable')
-
-print('Before you start, make sure the area detector IOC is in "Acquire mode"')
-#expo_threshold = 60 # in seconds Deprecated!
-FRAME_ACQUIRE_TIME = 0.1 
-AREA_DET_NAME = 'pe1c'
-TEMP_CONTROLLER_NAME = 'cs700'
+''' things that should be created and imported during start_up
+#xpdRE = _get_obj('xpdRE')
+#LiveTable = _get_obj('LiveTable')
 
 # set up the detector    
 # default settings for pe1c
-area_det = _get_obj(AREA_DET_NAME)
-area_det.cam.acquire_time.put(FRAME_ACQUIRE_TIME)
-temp_controller = _get_obj(TEMP_CONTROLLER_NAME)
+#area_det = _get_obj(AREA_DET_NAME)
+#area_det.cam.acquire_time.put(FRAME_ACQUIRE_TIME)
+#temp_controller = _get_obj(TEMP_CONTROLLER_NAME)
 
+'''
+
+print('Before you start, make sure the area detector IOC is in "Acquire mode"')
+#expo_threshold = 60 # in seconds Deprecated!
+
+def _areaDET(area_det_name):
+    global AREA_DET
+    AREA_DET = area_det_name
+
+def _tempController(temp_controller_name):
+    global TEMP_CONTROLLER
+    TEMP_CONTROLLER = temp_controller_name
+
+def _shutter(shutter_name):
+    global SHUTTER
+    SHUTTER = shutter_name
+
+def _bdir(b_dir_name):
+    global B_DIR
+    B_DIR = b_dir_name
+
+# analysis objects : not ready yet
+# db
+# LiveTable
+# get_events
+# get_images
 
 def dryrun(sample,scan,**kwargs):
     '''same as run but scans are not executed.


### PR DESCRIPTION
This pull request focuses on:
  - cleaning ambiguity on naming `home_dir` and `b_dir`
  - central config to B_DIR

`_start_beamtime` and `_end_beamtime` are now working correctly but many other places need to be refactored later.

Note: `999-load.py` in `xpdConfig` and `xpd_profile_file` are the same. Just an extra copy.