### PR TITLE
Lazy user modality

### DIFF
--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -19,7 +19,7 @@ class NewExptTest(unittest.TestCase):
         self.experimenters = [('van der Banerjee','S0ham',1),('Terban ',' Max',2)]
         #_make_clean_env()
         self.bt = _execute_start_beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters,home_dir=self.home_dir)     
-        self.stbt_list = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml']
+        self.stbt_list = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sc_ct.1s.yml','sc_ct.5s.yml','sc_ct1s.yml','sc_ct5s.yml','sc_ct10s.yml','sc_ct30s.yml']
 
     def tearDown(self):
         os.chdir(self.base_dir)

--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -126,7 +126,8 @@ class NewBeamtimeTest(unittest.TestCase):
         self.assertEqual(bt.md['bt_wavelength'],0.1812)
         os.chdir(self.base_dir)
         newobjlist = _get_yaml_list()
-        self.assertEqual(newobjlist,['bt_bt.yml','ex_l-user.yml','sa_l-user.yml'])
+        strtScnLst = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sc_ct.1s.yml','sc_ct.5s.yml','sc_ct1s.yml','sc_ct5s.yml','sc_ct10s.yml','sc_ct30s.yml']
+        self.assertEqual(newobjlist,strtScnLst)
     
     @unittest.expectedFailure
     def test_execute_end_beamtime(self):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -121,7 +121,7 @@ class XPD:
     @classmethod
     def list(cls, type=None):
         olist = cls.loadyamls(cls)
-        hlist = cls._get_hidden_list(cls)
+        hlist = _get_hidden_list()
         if type is None:
             iter = 0
             for i in olist:
@@ -160,7 +160,7 @@ class XPD:
 
     @classmethod
     def get(cls, index):
-        list = cls.loadyamls()
+        list = cls.loadyamls(cls)
         return list[index]
 
 #    @classmethod

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -19,8 +19,8 @@ import datetime
 import shutil
 from time import strftime
 from xpdacq.utils import _graceful_exit
-from xpdacq.beamtime import Beamtime, XPD, Experiment, Sample
-from xpdacq.beamtime import export_data
+from xpdacq.beamtime import Beamtime, XPD, Experiment, Sample, ScanPlan
+from xpdacq.beamtime import export_data,_clean_md_input,_get_hidden_list
 from xpdacq.glbl import glbl
 
 #datapath = glbl.dp()
@@ -171,11 +171,11 @@ def _start_beamtime(home_dir=None):
     safn = input('Please enter the SAF number for this beamtime: ')
     wavelength = input('Please enter the x-ray wavelength: ')
     print('Please enter a list of experimenters with syntax [("lastName","firstName",userID)]')
-    explist = input('default = []  ')
-    _explist = _clean_md_input(eval(explist))
-    
+    explist = input('default = []  ')   
     if explist == '':
         explist = []
+    _explist = _clean_md_input(explist)
+
     bt = _execute_start_beamtime(piname, safn, wavelength, _explist, home_dir)
     return bt
 
@@ -191,6 +191,12 @@ def _execute_start_beamtime(piname,safn,wavelength,explist,home_dir=None):
     # now populate the database with some dummy objects
     ex = Experiment('l-user',bt)
     sa = Sample('l-user',ex)
+    sc01 = ScanPlan('ct.1s','ct',{'exposure':0.1})
+    sc05 = ScanPlan('ct.5s','ct',{'exposure':0.5})
+    sc1 = ScanPlan('ct1s','ct',{'exposure':1.0})
+    sc5 = ScanPlan('ct5s','ct',{'exposure':5.0})
+    sc10 = ScanPlan('ct10s','ct',{'exposure':10.0})
+    sc30 = ScanPlan('ct30s','ct',{'exposure':30.0})
     return bt
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is for users who want to have rapid spec-like functionality

workaround is to pre-populate the database with ``l-user`` experiment and sample objects, and ``scanPlan`` objects