### PR TITLE
initial commit of updated start_beamtime sequence

### DIFF
--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -13,12 +13,18 @@ class NewExptTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = glbl.base
         self.home_dir = glbl.home
+        self.config_dir = glbl.xpdconfig
+        os.makedirs(self.config_dir, exist_ok=True)
         self.PI_name = 'Billinge '
-        self.saf_num = 123
+        self.saf_num = 234
         self.wavelength = 0.1812
         self.experimenters = [('van der Banerjee','S0ham',1),('Terban ',' Max',2)]
+        self.saffile = os.path.join(self.config_dir,'saf{}.yml'.format(self.saf_num))
         #_make_clean_env()
-        self.bt = _execute_start_beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters,home_dir=self.home_dir)     
+        loadinfo = {'saf number':self.saf_num,'PI last name':self.PI_name,'experimenter list':self.experimenters}
+        with open(self.saffile, 'w') as fo:
+            yaml.dump(loadinfo,fo)
+        self.bt = _start_beamtime(self.saf_num,home_dir=self.home_dir)     
         self.stbt_list = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sc_ct.1s.yml','sc_ct.5s.yml','sc_ct1s.yml','sc_ct5s.yml','sc_ct10s.yml','sc_ct30s.yml']
 
     def tearDown(self):
@@ -105,7 +111,7 @@ class NewExptTest(unittest.TestCase):
         self.assertIsInstance(self.ex,Experiment)
         self.assertEqual(self.ex.md['bt_experimenters'],[('van der Banerjee','S0ham',1),('Terban','Max',2)])
         self.assertEqual(self.ex.md['bt_piLast'],'Billinge')
-        self.assertEqual(self.ex.md['bt_safN'],123)
+        self.assertEqual(self.ex.md['bt_safN'],234)
         self.assertEqual(self.ex.md['bt_wavelength'],0.1812)
         self.assertEqual(self.ex.md['ex_name'],'myexp')
         uid1 = self.ex.md['ex_uid']
@@ -131,7 +137,7 @@ class NewExptTest(unittest.TestCase):
         self.assertIsInstance(self.sa,Sample)
         self.assertEqual(self.sa.md['bt_experimenters'],[('van der Banerjee','S0ham',1),('Terban','Max',2)])
         self.assertEqual(self.sa.md['bt_piLast'],'Billinge')
-        self.assertEqual(self.sa.md['bt_safN'],123)
+        self.assertEqual(self.sa.md['bt_safN'],234)
         self.assertEqual(self.sa.md['bt_wavelength'],0.1812)
         self.assertEqual(self.sa.md['ex_name'],'myexp')
         self.assertEqual(self.sa.md['sa_name'],'my sample')

--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -112,7 +112,7 @@ class NewExptTest(unittest.TestCase):
         self.assertEqual(self.ex.md['bt_experimenters'],[('van der Banerjee','S0ham',1),('Terban','Max',2)])
         self.assertEqual(self.ex.md['bt_piLast'],'Billinge')
         self.assertEqual(self.ex.md['bt_safN'],234)
-        self.assertEqual(self.ex.md['bt_wavelength'],0.1812)
+        self.assertEqual(self.ex.md['bt_wavelength'],None)
         self.assertEqual(self.ex.md['ex_name'],'myexp')
         uid1 = self.ex.md['ex_uid']
         newobjlist = _get_yaml_list()
@@ -138,7 +138,7 @@ class NewExptTest(unittest.TestCase):
         self.assertEqual(self.sa.md['bt_experimenters'],[('van der Banerjee','S0ham',1),('Terban','Max',2)])
         self.assertEqual(self.sa.md['bt_piLast'],'Billinge')
         self.assertEqual(self.sa.md['bt_safN'],234)
-        self.assertEqual(self.sa.md['bt_wavelength'],0.1812)
+        self.assertEqual(self.sa.md['bt_wavelength'],None)
         self.assertEqual(self.sa.md['ex_name'],'myexp')
         self.assertEqual(self.sa.md['sa_name'],'my sample')
         uid1 = self.sa.md['sa_uid']

--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import shutil
+import yaml
 from time import strftime
 from xpdacq.xpdacq import _areaDET
 from xpdacq.xpdacq import _tempController
@@ -21,10 +22,12 @@ class NewBeamtimeTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = glbl.base
         self.home_dir = os.path.join(self.base_dir,'xpdUser')
+        self.config_dir = os.path.join(self.base_dir,'xpdConfig')
         self.PI_name = 'Billinge '
-        self.saf_num = 123
+        self.saf_num = 123   # must be 123 for proper load of config yaml => don't change
         self.wavelength = 0.1812
         self.experimenters = [('van der Banerjee','S0ham',1),('Terban ',' Max',2)]
+        self.saffile = os.path.join(self.config_dir,'saf123.yml')
         #_make_clean_env()
 #        self.bt = _execute_start_beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters,home_dir=self.home_dir)
 
@@ -112,18 +115,23 @@ class NewBeamtimeTest(unittest.TestCase):
         bt = Beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters)
         self.assertIsInstance(bt,Beamtime)
         #maybe some more edge cases tested here?
-    
+
     def test_start_beamtime(self):
         os.chdir(self.base_dir)
-        # clean encironment checked above, so only check a case that works
+        # clean environment checked above, so only check a case that works
         os.mkdir(self.home_dir)
-        bt = _execute_start_beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters,home_dir=self.home_dir)
+        os.mkdir(self.config_dir)
+        loadinfo = {'saf number':self.saf_num,'PI last name':self.PI_name,'experimenter list':self.experimenters}
+        with open(self.saffile, 'w') as fo:
+            yaml.dump(loadinfo,fo)
+        self.assertTrue(os.path.isfile(self.saffile))
+        bt = _start_beamtime(self.saf_num,home_dir=self.home_dir)
         self.assertEqual(os.getcwd(),self.home_dir) # we should be in home, are we?
         self.assertIsInstance(bt,bts.Beamtime) # there should be a bt object, is there?
         self.assertEqual(bt.md['bt_experimenters'],[('van der Banerjee','S0ham',1),('Terban','Max',2)])
         self.assertEqual(bt.md['bt_piLast'],'Billinge')
         self.assertEqual(bt.md['bt_safN'],123)
-        self.assertEqual(bt.md['bt_wavelength'],0.1812)
+        self.assertEqual(bt.md['bt_wavelength'],None)
         os.chdir(self.base_dir)
         newobjlist = _get_yaml_list()
         strtScnLst = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sc_ct.1s.yml','sc_ct.5s.yml','sc_ct1s.yml','sc_ct5s.yml','sc_ct10s.yml','sc_ct30s.yml']

--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -100,7 +100,7 @@ class NewBeamtimeTest(unittest.TestCase):
 
     def test_bt_creation(self):
         _make_clean_env()
-        self.bt = Beamtime(self.PI_name,self.saf_num,self.wavelength,self.experimenters,base_dir=self.base_dir)
+        self.bt = Beamtime(self.PI_name,self.saf_num,wavelength=self.wavelength,experimenters=self.experimenters,base_dir=self.base_dir)
         self.assertIsInstance(self.bt,Beamtime)
         self.assertEqual(self.bt.md['bt_experimenters'],[('van der Banerjee','S0ham',1),('Terban','Max',2)])
         self.assertEqual(self.bt.md['bt_piLast'],'Billinge')

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -181,7 +181,7 @@ class XPD:
 #            return
     
 class Beamtime(XPD):
-    def __init__(self, pi_last, safn, wavelength, experimenters = [], **kwargs):
+    def __init__(self, pi_last, safn, wavelength=None, experimenters = [], **kwargs):
         self.name = 'bt'
         self.type = 'bt'
         self.md = {'bt_piLast': _clean_md_input(pi_last), 'bt_safN': _clean_md_input(safn), 

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -41,7 +41,8 @@ ALL_FOLDERS = [
 os.makedirs(BLCONFIG_DIR, exist_ok=True)
 tmp_safname = os.path.join(BLCONFIG_DIR,'saf123.yml')
 if not os.path.isfile(tmp_safname):
-    dummy_config = {'saf number':123,'PI last name':'simulation','experimenter list':[('PIlastname','PIfirstname',1123456),('Exp2lastname','Exp2firstname',654321)]}
+    dummy_config = {'saf number':123,'PI last name':'simulation','experimenter list':[('PIlastname','PIfirstname',1123456),('Exp2lastname','Exp2firstname',654321),
+                     ('Add more lines','as needed, one for each experimenter',98765)]}
     with open(tmp_safname, 'w') as fo:
         yaml.dump(dummy_config,fo)
 

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -1,10 +1,11 @@
 import os
 import socket
+import yaml
 from time import strftime
 
 # better to get this from a config file in the fullness of time
 HOME_DIR_NAME = 'xpdUser'
-CONFIG_DIR_NAME = 'xpdConfig'
+BLCONFIG_DIR_NAME = 'xpdConfig'
 BEAMLINE_HOST_NAME = 'xf28id1-ws2'
 BASE_DIR = os.path.expanduser('~/')
 ARCHIVE_BASE_DIR = os.path.expanduser('~/pe2_data/.userBeamtimeArchive')
@@ -20,13 +21,13 @@ else:
     ARCHIVE_BASE_DIR = os.path.join(BASE_DIR,'userSimulationArchive')
     print('==== Simulation being created in current directory:{} ===='.format(BASE_DIR))
 HOME_DIR = os.path.join(BASE_DIR, HOME_DIR_NAME)
-CONFIG_DIR = os.path.join(BASE_DIR, CONFIG_DIR_NAME)
+BLCONFIG_DIR = os.path.join(BASE_DIR, BLCONFIG_DIR_NAME)
 EXPORT_DIR = os.path.join(HOME_DIR, 'Export')
 YAML_DIR = os.path.join(HOME_DIR, 'config_base', 'yml')
 USER_BACKUP_DIR = os.path.join(ARCHIVE_BASE_DIR, USER_BACKUP_DIR_NAME)
 ALL_FOLDERS = [
         HOME_DIR,
-        CONFIG_DIR,
+        BLCONFIG_DIR,
         os.path.join(HOME_DIR, 'tiff_base'),
         os.path.join(HOME_DIR, 'dark_base'),
         YAML_DIR,
@@ -36,11 +37,20 @@ ALL_FOLDERS = [
         os.path.join(HOME_DIR, 'Import'),
         os.path.join(HOME_DIR, 'userAnalysis')
 ]
+# for simulation put a summy saf file in BLCONFIG_DIR
+os.makedirs(BLCONFIG_DIR, exist_ok=True)
+tmp_safname = os.path.join(BLCONFIG_DIR,'saf123.yml')
+if not os.path.isfile(tmp_safname):
+    dummy_config = {'saf number':123,'PI last name':'simulation','experimenter list':[('PIlastname','PIfirstname',1123456),('Exp2lastname','Exp2firstname',654321)]}
+    with open(tmp_safname, 'w') as fo:
+        yaml.dump(dummy_config,fo)
+
 
 class glbl():
 	#this behavior can be changed to include Tim's logic
     base = BASE_DIR
     home = HOME_DIR
+    xpdconfig = BLCONFIG_DIR
     export_dir = EXPORT_DIR
     yaml_dir = YAML_DIR
     allfolders = ALL_FOLDERS

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -24,6 +24,8 @@ from bluesky import Msg
 #from xpdacq.analysis import *
 from bluesky.plans import AbsScanPlan
 
+from xpdacq.utils import _graceful_exit
+
 ''' things that should be created and imported during start_up
 #xpdRE = _get_obj('xpdRE')
 #LiveTable = _get_obj('LiveTable')
@@ -103,6 +105,9 @@ def dryrun(sample,scan,**kwargs):
        return
     
 def _unpack_and_run(sample,scan,**kwargs):
+    # check to see if wavelength has been set
+    if not sample.md['bt_wavelength']:
+        sys.exit(_graceful_exit('Please have the instrument scientist set the wavelength value before proceeding.'))
     cmdo = Union(sample,scan)
     area_det = _get_obj('pe1c')
     parms = scan.md['sc_params']
@@ -115,14 +120,14 @@ def _unpack_and_run(sample,scan,**kwargs):
             subs.update({'stop':verify_files_saved})
 
     if scan.scan == 'ct':
-       get_light_images(cmdo,parms['exposure'],'pe1c',subs,**kwargs)
+        get_light_images(cmdo,parms['exposure'],'pe1c',subs,**kwargs)
     elif scan.scan == 'tseries':
-       collect_time_series(cmdo,parms['exposure'], parms['delay'], parms['num'],'pe1c', subs, **kwargs)
+        collect_time_series(cmdo,parms['exposure'], parms['delay'], parms['num'],'pe1c', subs, **kwargs)
     elif scan.scan == 'Tramp':
         collect_Temp_series(cmdo, parms['startingT'], parms['endingT'],parms['requested_Tstep'], parms['exposure'], 'pe1c', subs, **kwargs)
     else:
-       print('unrecognized scan type.  Please rerun with a different scan object')
-       return
+        print('unrecognized scan type.  Please rerun with a different scan object')
+        return
 
 def prun(sample,scan,**kwargs):
     '''on this 'sample' run this 'scan'


### PR DESCRIPTION
Now inputs are read from a saf<saf_number>.yml yaml file that is placed
in xpdConfig.
Making it easier for the beamline staff and getting ready for when we
have access to the PASS system.
Also getting rid of the horrible input('yuckiness') logic.