### PR TITLE
Version with bluesky objects mocked in simulation mode

### DIFF
--- a/tests/test_validate_dark.py
+++ b/tests/test_validate_dark.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock
 import os
 import shutil
 import time
@@ -20,9 +21,15 @@ _tempController()
 _verify_write()
 _LiveTable()
 from xpdacq.xpdacq import validate_dark, _yamify_dark, prun
+#from xpdacq.mock_objects import Cam
 
-shutter = glbl.SHUTTER
+shutter = glbl.shutter
 shutter.put(1)
+#glbl.area_det.number_of_sets.put = MagicMock(return_value=1)
+#glbl.area_det.cam = Cam()
+#glbl.area_det.cam.acquire_time.put = MagicMock(return_value=1)
+
+
 
 # this is here temporarily.  Simon wanted it out of the production code.  Needs to be refactored.
 # the issue is to mock RE properly.  This is basically prun without the call to RE which
@@ -132,7 +139,8 @@ class findRightDarkTest(unittest.TestCase):
         light_cnt_time = 0.2
         scanplan = ScanPlan('ctTest', 'ct', {'exposure':0.2})
         self.bt.set_wavelength(0.18448)
-        self.assertEqual(prun(self.sa, scanplan)['sc_params']['dk_field_uid'], dark_uid)
+        prun(self.sa, scanplan)
+        self.assertEqual(scanplan.md['sc_params']['dk_field_uid'], dark_uid)
 
     @unittest.skip('skipping test with prun.  Need to refactor prun to take a dk_expiration_time optional variable?')
     def test_prun_with_no_matched_dark(self):

--- a/tests/test_validate_dark.py
+++ b/tests/test_validate_dark.py
@@ -9,17 +9,17 @@ import numpy as np
 import copy
 from xpdacq.glbl import glbl
 #from xpdacq.xpdacq import validate_dark,  _yamify_dark 
-from xpdacq.glbl import _areaDET, _tempController
+#from xpdacq.glbl import _areaDET, _tempController
 #from xpdacq.glbl import _shutter, _verify_write
-from xpdacq.glbl import _verify_write
-from xpdacq.glbl import _LiveTable
+#from xpdacq.glbl import _verify_write
+#from xpdacq.glbl import _LiveTable
 from xpdacq.beamtime import Beamtime, Experiment, ScanPlan, Sample
 from xpdacq.beamtimeSetup import _start_beamtime, _end_beamtime
-_areaDET()
-_tempController()
+#_areaDET()
+#_tempController()
 #_shutter()
-_verify_write()
-_LiveTable()
+#_verify_write()
+#_LiveTable()
 from xpdacq.xpdacq import validate_dark, _yamify_dark, prun
 #from xpdacq.mock_objects import Cam
 

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -18,38 +18,38 @@ USER_BACKUP_DIR_NAME = strftime('%Y')
 DARK_WINDOW = 15 # default value, in terms of minute
 FRAME_ACQUIRE_TIME = 0.1 # pe1 frame acq time
 
-def _areaDET(area_det_obj=None):
-    global AREA_DET
-    AREA_DET = area_det_obj
+#def _areaDET(area_det_obj=None):
+#    global AREA_DET
+#    AREA_DET = area_det_obj
 
-def _tempController(temp_controller_obj=None):
-    global TEMP_CONTROLLER
-    TEMP_CONTROLLER = temp_controller_obj
+#def _tempController(temp_controller_obj=None):
+#    global TEMP_CONTROLLER
+#    TEMP_CONTROLLER = temp_controller_obj
 
 #def _shutter(shutter_obj=None):
 #    global SHUTTER
 #    SHUTTER = shutter_obj
 
-def _verify_write(verify_files_saved_obj=None):
-    global VERIFY_WRITE
-    VERIFY_WRITE = verify_files_saved_obj
+#def _verify_write(verify_files_saved_obj=None):
+#    global VERIFY_WRITE
+#    VERIFY_WRITE = verify_files_saved_obj
 
-def _LiveTable(livetable_obj=None):
-    global LIVETABLE
-    LIVETABLE = livetable_obj
+#def _LiveTable(livetable_obj=None):
+#    global LIVETABLE
+#    LIVETABLE = livetable_obj
 
 # analysis objects, maybe we should move them out in the future
-def _dataBroker(databroker_obj=None):
-    global DB
-    DB = databroker_obj
+#def _dataBroker(databroker_obj=None):
+#    global DB
+#    DB = databroker_obj
 
-def _getEvents(get_events_obj=None):
-    global GET_ENV
-    GET_ENV = get_events_obj
+#def _getEvents(get_events_obj=None):
+#    global GET_ENV
+#    GET_ENV = get_events_obj
 
-def _getImages(get_images_obj=None):
-    global GET_IMG
-    GET_IMG = get_images_obj
+#def _getImages(get_images_obj=None):
+#    global GET_IMG
+#    GET_IMG = get_images_obj
 
 xpdRE = RunEngine()
 xpdRE.md['owner'] = 'xf28id1'

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -73,6 +73,7 @@ BLCONFIG_DIR = os.path.join(BASE_DIR, BLCONFIG_DIR_NAME)
 EXPORT_DIR = os.path.join(HOME_DIR, 'Export')
 YAML_DIR = os.path.join(HOME_DIR, 'config_base', 'yml')
 DARK_YAML_NAME = os.path.join(YAML_DIR, '_dark_scan_list.yaml')
+CONFIG_BASE = os.path.join(HOME_DIR, 'config_base')
 
 USER_BACKUP_DIR = os.path.join(ARCHIVE_BASE_DIR, USER_BACKUP_DIR_NAME)
 ALL_FOLDERS = [
@@ -81,7 +82,7 @@ ALL_FOLDERS = [
         os.path.join(HOME_DIR, 'tiff_base'),
         os.path.join(HOME_DIR, 'dark_base'),
         YAML_DIR,
-        os.path.join(HOME_DIR, 'config_base'),
+        CONFIG_BASE,
         os.path.join(HOME_DIR, 'userScripts'),
         EXPORT_DIR,
         os.path.join(HOME_DIR, 'Import'),
@@ -101,6 +102,7 @@ class glbl():
     home = HOME_DIR
     xpdconfig = BLCONFIG_DIR
     export_dir = EXPORT_DIR
+    config_base = CONFIG_BASE
     yaml_dir = YAML_DIR
     allfolders = ALL_FOLDERS
     archive_dir = USER_BACKUP_DIR

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -15,8 +15,11 @@ BEAMLINE_HOST_NAME = 'xf28id1-ws2'
 BASE_DIR = os.path.expanduser('~/')
 ARCHIVE_BASE_DIR = os.path.expanduser('~/pe2_data/.userBeamtimeArchive')
 USER_BACKUP_DIR_NAME = strftime('%Y')
-DARK_WINDOW = 15 # default value, in terms of minute
+DARK_WINDOW = 30 # default value, in terms of minute
 FRAME_ACQUIRE_TIME = 0.1 # pe1 frame acq time
+OWNER = 'xf28id1'
+BEAMLINE_ID = 'xpd'
+GROUP = 'XPD'
 
 #def _areaDET(area_det_obj=None):
 #    global AREA_DET
@@ -50,11 +53,6 @@ FRAME_ACQUIRE_TIME = 0.1 # pe1 frame acq time
 #def _getImages(get_images_obj=None):
 #    global GET_IMG
 #    GET_IMG = get_images_obj
-
-xpdRE = RunEngine()
-xpdRE.md['owner'] = 'xf28id1'
-xpdRE.md['beamline_id'] = 'xpd'
-xpdRE.md['group'] = 'XPD'
 
 hostname = socket.gethostname()
 if hostname == BEAMLINE_HOST_NAME:
@@ -119,6 +117,11 @@ class glbl():
     get_events = None
     get_images = None
     verify_files_saved = None
+
+    xpdRE = RunEngine()
+    xpdRE.md['owner'] = OWNER
+    xpdRE.md['beamline_id'] = BEAMLINE_ID
+    xpdRE.md['group'] = GROUP
     
     if hostname != BEAMLINE_HOST_NAME:
         shutter = mock_shutter()

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -2,10 +2,11 @@ import os
 import socket
 import yaml
 import numpy as np
+from unittest.mock import MagicMock
 from time import strftime, sleep
 from bluesky.run_engine import RunEngine
 # test at XPD
-from xpdacq.mock_objects import mock_shutter, mock_livetable#, mock_areadetector 
+from xpdacq.mock_objects import mock_shutter, mock_livetable#, Cam, , mock_areadetector
 
 # better to get this from a config file in the fullness of time
 HOME_DIR_NAME = 'xpdUser'
@@ -55,16 +56,18 @@ xpdRE.md['owner'] = 'xf28id1'
 xpdRE.md['beamline_id'] = 'xpd'
 xpdRE.md['group'] = 'XPD'
 
-
 hostname = socket.gethostname()
 if hostname == BEAMLINE_HOST_NAME:
     # real experiment
+    simulation = False
     from bluesky.register_mds import register_mds
     register_mds(xpdRE)
-    pass
 else:
+    simulation = True
     BASE_DIR = os.getcwd()
     ARCHIVE_BASE_DIR = os.path.join(BASE_DIR,'userSimulationArchive')
+    xpdRE = MagicMock()
+
     print('==== Simulation being created in current directory:{} ===='.format(BASE_DIR))
 
 HOME_DIR = os.path.join(BASE_DIR, HOME_DIR_NAME)
@@ -118,9 +121,18 @@ class glbl():
     verify_files_saved = None
     
     if hostname != BEAMLINE_HOST_NAME:
-        SHUTTER = mock_shutter()
+        shutter = mock_shutter()
         LiveTable = mock_livetable
-        area_det = mock_areadetector
+        #area_det = mock_areadetector()
+        area_det = MagicMock()
+        area_det.cam = MagicMock()
+        area_det.cam.acquire_time = MagicMock()
+        area_det.cam.acquire_time.put = MagicMock(return_value=1)
+        area_det.cam.acquire_time.get = MagicMock(return_value=1)
+        area_det.number_of_sets = MagicMock()
+        area_det.number_of_sets.put = MagicMock(return_value=1)
+
+        temp_controller = None
 
 
 if __name__ == '__main__':

--- a/xpdacq/mock_objects.py
+++ b/xpdacq/mock_objects.py
@@ -17,6 +17,14 @@ class mock_livetable():
     	self.mylist = mylist
 
 # commented out as unfinished error
+
+
 #class mock_areadetector():
-	#@property
-	#def number_of_sets(self):
+#    def number_of_sets(self):#
+#	    pass
+
+#class Cam(mock_areadetector):
+#    def acquire_time(self):
+#        self.put = 1
+#        pass
+

--- a/xpdacq/mock_objects.py
+++ b/xpdacq/mock_objects.py
@@ -1,7 +1,6 @@
 import numpy as np
 from time import sleep
 
-
 class mock_shutter():
     def put(self,value):
         pass
@@ -10,7 +9,6 @@ class mock_shutter():
         callback = round(np.random.rand())
         sleep(0.1)
         return callback
-
 
 class mock_livetable():
     def __init__(self,mylist):

--- a/xpdacq/mock_objects.py
+++ b/xpdacq/mock_objects.py
@@ -16,15 +16,4 @@ class mock_livetable():
     def __init__(self,mylist):
     	self.mylist = mylist
 
-# commented out as unfinished error
-
-
-#class mock_areadetector():
-#    def number_of_sets(self):#
-#	    pass
-
-#class Cam(mock_areadetector):
-#    def acquire_time(self):
-#        self.put = 1
-#        pass
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -149,7 +149,7 @@ def _load_calibration(calibration_file_name = None):
     config_dict : dict
     a dictionary containing calibration parameters calculated from SrXplanar
     '''
-    config_dir = os.path.join(glbl.config_dir, 'config_base') # FIXME - remove it after make config_dir an attribute
+    config_dir = glbl.config_base
     f_list = [ f for f in os.listdir(config_dir) if f.endswith('cfg')]
     if not f_list:
         return # no config at all

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -45,8 +45,6 @@ area_det = glbl.area_det
 LiveTable = glbl.LiveTable
 temp_controller = glbl.temp_controller
 
-#expo_threshold = 60 # in seconds Deprecated!
-
 def dryrun(sample,scan,**kwargs):
     '''same as run but scans are not executed.
     
@@ -60,7 +58,8 @@ def dryrun(sample,scan,**kwargs):
     #area_det = _get_obj('pe1c')
     parms = scan.md['sc_params']
     subs={}
-    if 'subs' in parms: subsc = parms['subs']
+    if 'subs' in parms: 
+        subsc = parms['subs']
     for i in subsc:
         if i == 'livetable':
             subs.update({'all':LiveTable([area_det, temp_controller])})
@@ -150,7 +149,7 @@ def _load_calibration(calibration_file_name = None):
     config_dict : dict
     a dictionary containing calibration parameters calculated from SrXplanar
     '''
-    config_dir = os.path.join(glbl.home, 'config_base') # FIXME - remove it after make config_dir an attribute
+    config_dir = os.path.join(glbl.config_dir, 'config_base') # FIXME - remove it after make config_dir an attribute
     f_list = [ f for f in os.listdir(config_dir) if f.endswith('cfg')]
     if not f_list:
         return # no config at all
@@ -190,7 +189,8 @@ def prun(sample,scanplan,**kwargs):
     scanplan - scanplan metadata object
     **kwargs - dictionary that will be passed through to the run-engine metadata
     '''
-    if scanplan.shutter: _open_shutter()
+    if scanplan.shutter: 
+        _open_shutter()
     scanplan.md.update({'xp_isprun':True})
     light_cnt_time = scanplan.md['sc_params']['exposure']
     expire_time = glbl.dk_window

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -198,7 +198,7 @@ def prun(sample,scanplan,**kwargs):
     if not dark_field_uid:
         dark_field_uid = dark(sample, scanplan, **kwargs)
         # remove is_dark tag in md
-        dummy = scanplan.md.pop('xp_isdark')
+        dummy = scanplan.md.pop('xp_isdark') 
     scanplan.md['sc_params'].update({'dk_field_uid': dark_field_uid})
     scanplan.md['sc_params'].update({'dk_window':expire_time})
     try:
@@ -228,7 +228,7 @@ def dark(sample,scan,**kwargs):
     _unpack_and_run(sample,scan,**kwargs)
     dark_time = time.time() # get timestamp by the end of dark_scan 
     dark_def = (dark_uid, dark_exposure, dark_time)
-    _yamify_dark(dark_def) 
+    scan.md.update({'xp_isdark':False}) #reset
     _close_shutter()
     return dark_uid
     


### PR DESCRIPTION
still more cleaning needed on globals, but this is loading properly and running even when in xpdacq is called, so now we can test prun and other functions with unittests.