### PR TITLE
Work exposure class

### DIFF
--- a/tests/test_validate_dark.py
+++ b/tests/test_validate_dark.py
@@ -13,8 +13,8 @@ from xpdacq.beamtimeSetup import _start_beamtime, _end_beamtime
 from xpdacq.xpdacq import validate_dark, _yamify_dark, prun, _read_dark_yaml
 #from xpdacq.mock_objects import Cam
 
-shutter = glbl.shutter
-shutter.put(1)
+#shutter = glbl.shutter
+#shutter.put(1)
 #glbl.area_det.number_of_sets.put = MagicMock(return_value=1)
 #glbl.area_det.cam = Cam()
 #glbl.area_det.cam.acquire_time.put = MagicMock(return_value=1)

--- a/xpdacq/control.py
+++ b/xpdacq/control.py
@@ -15,9 +15,13 @@
 #from xpdacq.glbl import SHUTTER as shutter
 from xpdacq.glbl import glbl
 import time
+from xpdacq.mock_objects import mock_shutter
 
 shutter = glbl.shutter
 
+# check it before used it
+if not shutter:
+    shutter = mock_shutter()
 
 def _open_shutter():
     shutter.put(1)

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -4,7 +4,6 @@ import yaml
 import numpy as np
 from unittest.mock import MagicMock
 from time import strftime, sleep
-from bluesky.run_engine import RunEngine
 from xpdacq.mock_objects import mock_shutter, mock_livetable#, Cam, , mock_areadetector
 
 # better to get this from a config file in the fullness of time
@@ -20,6 +19,7 @@ OWNER = 'xf28id1'
 BEAMLINE_ID = 'xpd'
 GROUP = 'XPD'
 
+'''
 xpdRE = RunEngine()
 xpdRE.md['owner'] = 'xf28id1'
 xpdRE.md['beamline_id'] = 'xpd'
@@ -38,6 +38,7 @@ else:
     xpdRE = MagicMock()
 
     print('==== Simulation being created in current directory:{} ===='.format(BASE_DIR))
+'''
 
 HOME_DIR = os.path.join(BASE_DIR, HOME_DIR_NAME)
 BLCONFIG_DIR = os.path.join(BASE_DIR, BLCONFIG_DIR_NAME)
@@ -70,6 +71,7 @@ if not os.path.isfile(tmp_safname):
         yaml.dump(dummy_config,fo)
 
 class glbl():
+    beamline_host_name = BEAMLINE_HOST_NAME
     base = BASE_DIR
     home = HOME_DIR
     xpdconfig = BLCONFIG_DIR
@@ -84,20 +86,28 @@ class glbl():
     dk_window = DARK_WINDOW
     frame_acq_time = FRAME_ACQUIRE_TIME
     auto_dark = True
+    owner = OWNER
+    beamline_id = BEAMLINE_ID
+    group = GROUP
+    # objects for collection activities
+    Msg = None
+    xpdRE = None
+    Count = None
+    AbsScanPlan = None
+
     area_det = None
     shutter = None
     LiveTable = None
+    temp_controller = None
 
+    # objects for analysis activities
     db = None
     get_events = None
     get_images = None
     verify_files_saved = None
-
-    xpdRE = RunEngine()
-    xpdRE.md['owner'] = OWNER
-    xpdRE.md['beamline_id'] = BEAMLINE_ID
-    xpdRE.md['group'] = GROUP
     
+    # this block of code has been moved to 999-load.py. Clean it after testing at XPD
+    '''   
     if hostname != BEAMLINE_HOST_NAME:
         shutter = mock_shutter()
         LiveTable = mock_livetable
@@ -109,9 +119,7 @@ class glbl():
         area_det.cam.acquire_time.get = MagicMock(return_value=1)
         area_det.number_of_sets = MagicMock()
         area_det.number_of_sets.put = MagicMock(return_value=1)
-
-        temp_controller = None
-
+    '''
 
 if __name__ == '__main__':
     print(glbl.dp().home)

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -26,6 +26,7 @@ from configparser import ConfigParser
 
 from xpdacq.utils import _graceful_exit
 from xpdacq.glbl import glbl
+
 from xpdacq.beamtime import Union, Xposure, ScanPlan
 from xpdacq.control import _close_shutter, _open_shutter
 
@@ -39,11 +40,14 @@ from bluesky.plans import AbsScanPlan
 
 print('Before you start, make sure the area detector IOC is in "Acquire mode"')
 
-
 # top definition for minial impacts on the code. Can be changed later
+Msg = glbl.Msg # still leave Msg alive, just in case
+xpdRE = glbl.xpdRE
+Count = glbl.Count
+AbsScanPlan = glbl.AbsScanPlan
 area_det = glbl.area_det
 LiveTable = glbl.LiveTable
-temp_controller = glbl.temp_controller
+temp_controller = glbl
 
 def dryrun(sample,scan,**kwargs):
     '''same as run but scans are not executed.

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -79,16 +79,17 @@ def dryrun(sample,scan,**kwargs):
     else:
        print('unrecognized scan type.  Please rerun with a different scan object')
        return
-    
-def _unpack_and_run(sample,scan,**kwargs):
+
+def _unpack_and_run(scan, **kwargs):   
+#def _unpack_and_run(sample,scan,**kwargs):
     # check to see if wavelength has been set
     # bug
-    if not sample.md['bt_wavelength']:
+    if not scan.md['bt_wavelength']:
         print('WARNING: There is no wavelength information in your sample acquire object')
-    cmdo = Union(sample,scan)
+    #cmdo = Union(sample,scan) # this should happen before _unpack_and_run
     parms = scan.md['sc_params']
     subs={}
-    if 'subs' in parms: 
+    if 'subs' in parms:
         subsc = parms['subs']
     for i in subsc:
         if i == 'livetable':
@@ -96,12 +97,21 @@ def _unpack_and_run(sample,scan,**kwargs):
         elif i == 'verify_write':
             subs.update({'stop':verify_files_saved})
 
+    if scan['sc_type'] == 'ct':
+        get_light_images(scan, parms['exposure'], area_det, subs,**kwargs)
+    elif scan['sc_type'] == 'tseries':
+        collect_time_series(scan, parms['exposure'], parms['delay'], parms['num'], area_det, subs, **kwargs)
+    elif scan['sc_type'] == 'Tramp':
+        collect_Temp_series(scan, parms['startingT'], parms['endingT'],parms['requested_Tstep'], parms['exposure'], area_det, subs, **kwargs)
+
+    '''
     if scan.scan == 'ct':
         get_light_images(cmdo,parms['exposure'], area_det, subs,**kwargs)
     elif scan.scan == 'tseries':
         collect_time_series(cmdo,parms['exposure'], parms['delay'], parms['num'], area_det, subs, **kwargs)
     elif scan.scan == 'Tramp':
         collect_Temp_series(cmdo, parms['startingT'], parms['endingT'],parms['requested_Tstep'], parms['exposure'], area_det, subs, **kwargs)
+    '''
     else:
         print('unrecognized scan type.  Please rerun with a different scan object')
         return
@@ -198,10 +208,12 @@ def prun(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
     auto_dark - optional. Type auto_dark = False to suppress the automatic collection of a dark image (default = True). Strongly recommend to leave as True unless problems are encountered
     **kwargs - dictionary that will be passed through to the run-engine metadata
     '''
-    if scanplan.shutter:
+    # create Scan object
+    scan = Union(sample, scanplan)
+    if scan.shutter:
         _open_shutter()
-    scanplan.md.update({'xp_isprun':True})
-    light_cnt_time = scanplan.md['sc_params']['exposure']
+    scan.md.update({'xp_isprun':True})
+    light_cnt_time = scan.md['sc_params']['exposure']
     expire_time = glbl.dk_window
     # user can also specify auto_dark in argument to overwrite glbl setting
     if auto_dark:
@@ -214,18 +226,19 @@ def prun(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
                     'ct',{'exposure':light_cnt_time})
             dark_field_uid = dark(sample, auto_dark_scanplan)
             time.sleep(2.5) # this hasn't been solved as of 03/11/2016
-        scanplan.md['sc_params'].update({'dk_field_uid': dark_field_uid})
-        scanplan.md['sc_params'].update({'dk_window':expire_time})
+        scan.md['sc_params'].update({'dk_field_uid': dark_field_uid})
+        scan.md['sc_params'].update({'dk_window':expire_time})
     try:
         (config_dict, config_name) = _load_calibration_file()
         scan.md.update({'xp_config_dict':config_dict})
         scan.md.update({'xp_config_name':config_name})
     except TypeError: # iterating on on None object causes TypeError
         print('INFO: No calibration file found in config_base. Scan will still keep going on')
-    if scanplan.shutter: 
+    if scan.shutter: 
         _open_shutter()
-    _unpack_and_run(sample,scanplan,**kwargs)
-    if scanplan.shutter: 
+    #_unpack_and_run(sample,scanplan,**kwargs)
+    _unpack_and_run(scan, **kwargs) # all md should be ready before _unpack_and_run
+    if scan.shutter: 
         _close_shutter()
 
 def calibration(sample, scanplan, **kwargs):
@@ -241,7 +254,7 @@ def calibration(sample, scanplan, **kwargs):
     prun(sample, _scanplan)
     # this way is cleaner and dark is collected as well. but "no calibration file" warning might appear while people are doing calibration run.
 
-def dark(sample,scan,**kwargs):
+def dark(sample, scanplan, **kwargs):
     '''on this 'scan' get dark images
     
     Arguments:
@@ -249,17 +262,19 @@ def dark(sample,scan,**kwargs):
     scan - scan metadata object
     **kwargs - dictionary that will be passed through to the run-engine metadata
     '''
-        # print information to user since we might call dark during prun.
+    scan = Union(sample, scanplan)
     dark_uid = str(uuid.uuid4())
     dark_exposure = scan.md['sc_params']['exposure']
     _close_shutter()
     scan.md.update({'xp_isdark':True})
     # we need a hook to search this dark frame later on
     scan.md.update({'xp_dark_uid':dark_uid})
-    _unpack_and_run(sample,scan,**kwargs)
+    #_unpack_and_run(sample,scan,**kwargs)
+    _unpack_and_run(scan, **kwargs)
     dark_time = time.time() # get timestamp by the end of dark_scan 
     dark_def = (dark_uid, dark_exposure, dark_time)
-    scan.md.update({'xp_isdark':False}) #reset
+    _yamify_dark(dark_def)
+    #scan.md.update({'xp_isdark':False}) #reset should be unnecessary
     _close_shutter()
     return dark_uid
     


### PR DESCRIPTION
Finished implementing new `Scan` object inside `prun`, as mentioned in issue #129.
Code pass all unittests and is able to run under simulation environment at this stage. 

I am inheriting the logic from PR #135 in this PR but I can edit accordingly after we decide how we are going to handle and load global objects. This edit should be fairly quick.