### PR TITLE
Add background and dryrun function

### DIFF
--- a/tests/test_scans.py
+++ b/tests/test_scans.py
@@ -14,35 +14,6 @@ from xpdacq.beamtimeSetup import _start_beamtime, _end_beamtime
 from xpdacq.xpdacq import prun, calibration, dark, _auto_dark_collection, _auto_load_calibration_file
 from xpdacq.control import _open_shutter, _close_shutter
 
-# this is here temporarily.  Simon wanted it out of the production code.  Needs to be refactored.
-# the issue is to mock RE properly.  This is basically prun without the call to RE which
-# isn't properly mocked yet.
-def _unittest_prun(sample,scan,**kwargs):
-    '''on this 'sample' run this 'scan'
-
-    this function doesn't control shutter nor trigger run engine. It is designed to test functionality
-
-    Arguments:
-    sample - sample metadata object
-    scan - scan metadata object
-    **kwargs - dictionary that will be passed through to the run-engine metadata
-    '''
-    scan.md.update({'xp_isprun':True})
-    light_cnt_time = scan.md['sc_params']['exposure']
-    expire_time = glbl.dk_window
-    dark_field_uid = validate_dark(light_cnt_time, expire_time)
-    if not dark_field_uid: dark_field_uid = 'can not find a qualified dark uid'
-    scan.md['sc_params'].update({'dk_field_uid': dark_field_uid})
-    scan.md['sc_params'].update({'dk_window':expire_time})
-    return scan.md
-
-def ideal_prun(sample, scanplan, **kwargs):
-    ''' a note to remind myself '''
-    scan = Scan(samplm, scanplan)
-    scan.md.update({'sc_isprun':True})
-    _executes_scan(scan)
-    return
-
 class NewScanTest(unittest.TestCase):
     def setUp(self):
         self.base_dir = glbl.base
@@ -192,6 +163,24 @@ class NewScanTest(unittest.TestCase):
         self.assertFalse('sc_isdark' in self.sp.md)
 
     def test_calibration(self):
+        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sc = Scan(self.sa, self.sp)
+        self.assertEqual(self.sc.sp, self.sp)
+        calibration(self.sa, self.sp)
+        # is xpdRE used?
+        self.assertTrue(glbl.xpdRE.called)
+        # is md updated?
+        self.assertFalse(glbl.xpdRE.call_args_list[-1][1] == self.sc.md)
+        # is calibration labeled eventually?
+        self.assertTrue('sc_iscalibration' in glbl.xpdRE.call_args_list[-1][1])
+        # is auto_dark executed?
+        self.assertTrue('sc_dk_field_uid' in glbl.xpdRE.call_args_list[-1][1])
+        # is calibration loaded? -> No
+        self.assertFalse('sc_calibration_file_name' in glbl.xpdRE.call_args_list[-1][1])
+        # is  ScanPlan.md remain unchanged after scan?
+        self.assertFalse('sc_iscalibration' in self.sp.md)
+
+    def test_dryrun(self):
         self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -216,7 +216,7 @@ def _auto_load_calibration_file():
     config_md_dict = {'sc_calibration_parameters':config_dict, 'sc_calibration_file_name': os.path.basename(config_in_use), 'sc_calibration_file_timestamp':config_time}
     return config_md_dict
 
-def prun(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
+def prun(sample, scanplan, auto_dark = None, **kwargs):
     ''' on this sample run this scanplan
 
     Parameters
@@ -228,15 +228,17 @@ def prun(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
         object carries metadata of ScanPlan object
 
     auto_dark : bool
-        option of automated dark collection. Set to true to allow collect dark automatically during scans
+        option of automated dark collection. Default is True to allow collect dark automatically during scans
     '''
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_isprun':True})
+    if not auto_dark:
+        auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = True, light_frame = True, dryrun = False)
     return
 
-def calibration(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
+def calibration(sample, scanplan, auto_dark = None, **kwargs):
     ''' on this calibration sample (calibrant) run this scanplan
 
     Parameters
@@ -248,16 +250,18 @@ def calibration(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
         object carries metadata of ScanPlan object
 
     auto_dark : bool
-        option of automated dark collection. Set to true to allow collect dark automatically during scans
+        option of automated dark collection. Default is True to allow collect dark automatically during scans
     '''
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_iscalibration':True})
     # only auto_dark is exposed to user
+    if not auto_dark:
+        auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = False, light_frame = True, dryrun = False)
     return
 
-def background(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
+def background(sample, scanplan, auto_dark = None, **kwargs):
     ''' on this sample (kepton tube) run this scanplan
 
     Parameters
@@ -269,16 +273,18 @@ def background(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
         object carries metadata of ScanPlan object
 
     auto_dark : bool
-        option of automated dark collection. Set to true to allow collect dark automatically during scans
+        option of automated dark collection. Default is True to allow collect dark automatically during scans
     '''
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_isbackground':True})
     # only auto_dark is exposed to user
+    if not auto_dark:
+        auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = False, light_frame = True, dryrun = False)
     return
 
-def setupscan(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
+def setupscan(sample, scanplan, auto_dark = None, **kwargs):
     ''' on this sample run this scanplan as a setupscan
 
     Parameters
@@ -290,12 +296,14 @@ def setupscan(sample, scanplan, auto_dark = glbl.auto_dark, **kwargs):
         object carries metadata of ScanPlan object
 
     auto_dark : bool
-        option of automated dark collection. Set to true to allow collect dark automatically during scans
+        option of automated dark collection. Default is True to allow collect dark automatically during scans
     '''
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_issetupscan':True})
     # only auto_dark is exposed to user
+    if not auto_dark:
+        auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = False, light_frame = True, dryrun = False)
     return
 
@@ -339,9 +347,6 @@ def dryrun(sample, scanplan, **kwargs):
 
     scanplan : xpdAcq.beamtime.ScanPlan object
         object carries metadata of ScanPlan object
-
-    auto_dark : bool
-        option of automated dark collection. Set to true to allow collect dark automatically during scans
     '''
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -345,8 +345,7 @@ def dryrun(sample, scanplan, **kwargs):
     '''
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})
-    scan.md.update({'sc_isdryrun':True})
-    _execute_scans(scan, auto_dark = False, auto_calibration = False, light_frame = True, dryrun = True)
+    _execute_scans(scan, auto_dark = False, auto_calibration = False, light_frame = False, dryrun = True)
     return
 
 def get_light_images(scan, exposure = 1.0, det=area_det, subs_dict={}, dryrun = False):
@@ -387,7 +386,7 @@ def get_light_images(scan, exposure = 1.0, det=area_det, subs_dict={}, dryrun = 
 
     plan = Count([area_det])
     if dryrun:
-       _get_light_image_dryrun(md_dict) 
+        _get_light_image_dryrun(md_dict)
     else:    
         xpdRE(plan, subs_dict, **md_dict)
         if xpdRE.state == 'paused':
@@ -404,8 +403,7 @@ def _get_light_image_dryrun(md_dict):
     print('(i.e. accessible as a single tiff file)')
     print('')
     print('The metadata saved with the scan will be:')
-    print(md_dict) # make it prettier
-    return md_dict
+    print(md_dict) # make it prettier later
 
 
 def collect_Temp_series(scan, Tstart, Tstop, Tstep, exposure = 1.0, det= area_det, subs_dict={}, dryrun = False):


### PR DESCRIPTION
Add `background` and `dryrun` function and include `dryrun` option to `_unpack_and_run`. Code passed both simulation and `unittest`.

I still leave `get_light_image_dryrun` and other similar dryrun function in in `xpdaca.py`. If this refactoring is okay, I will clean them up in next commit. 