### PR TITLE
Refactor dk_window

### DIFF
--- a/tests/test_scans.py
+++ b/tests/test_scans.py
@@ -42,7 +42,7 @@ class NewScanTest(unittest.TestCase):
             shutil.rmtree(os.path.join(glbl.base,'xpdConfig'))
 
     def test_auto_dark_collection(self):
-        self.sp_set_dk_window = ScanPlan('unittest_count','ct', {'exposure': 0.1, 'dk_window':25575}, shutter = False)
+        self.sp_set_dk_window = ScanPlan('unittest_count','ct', {'exposure': 0.1}, dk_window = 25575, shutter = False)
         self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
         self.sc_set_dk_window = Scan(self.sa, self.sp_set_dk_window)
         self.sc = Scan(self.sa, self.sp)
@@ -51,8 +51,8 @@ class NewScanTest(unittest.TestCase):
         # test if md is updated
         self.assertTrue('sc_dk_field_uid' in auto_dark_md_dict_set_dk_window and 'sc_dk_field_uid' in auto_dark_md_dict)
         # test if dk_window is overwrittten
-        self.assertEqual(glbl.dk_window, auto_dark_md_dict['sc_dk_window'])
-        self.assertEqual(25575, auto_dark_md_dict_set_dk_window['sc_dk_window'])
+        self.assertEqual(glbl.dk_window, self.sp.md['sp_dk_window'])
+        self.assertEqual(25575, self.sp_set_dk_window.md['sp_dk_window'])
 
     def test_auto_load_calibration(self):
         self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)

--- a/tests/test_scans.py
+++ b/tests/test_scans.py
@@ -95,7 +95,7 @@ class NewScanTest(unittest.TestCase):
         self.assertEqual(modified_auto_calibration_md_dict['sc_calibration_parameters']['Others']['avgmask'], 'False')
 
     def test_new_prun_with_auto_dark_and_auto_calibration(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1, 'dk_window':32767}, shutter = False)
+        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1, 'dk_window':32767}, dk_window = 32767, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         cfg_f_name = 'srxconfig.cfg'
@@ -112,7 +112,7 @@ class NewScanTest(unittest.TestCase):
         # is auto_dark executed?
         self.assertTrue('sc_dk_field_uid' in glbl.xpdRE.call_args_list[-1][1])
         # is dk_window changed as ScanPlan object changed??
-        self.assertEqual(glbl.xpdRE.call_args_list[-1][1]['sc_dk_window'], 32767)
+        self.assertEqual(glbl.xpdRE.call_args_list[-1][1]['sp_dk_window'], 32767)
         # is calibration loaded?
         self.assertEqual(glbl.xpdRE.call_args_list[-1][1]['sc_calibration_file_name'], cfg_f_name)
         # is  ScanPlan.md remain unchanged after scan?

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -144,7 +144,6 @@ class XPD:
         yaml.dump(hidden_list, fo)
         return hidden_list
 
-    # test at XPD
     def _init_dark_scan_list(self):
         dark_scan_list = []
         with open(glbl.dk_yaml,'w') as f:

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -258,7 +258,7 @@ class ScanPlan(XPD):
                    for each event.  It introduces a significant overhead so mostly used for
                    testing.
     '''
-    def __init__(self,name, scanplan_type, scanplan_params, shutter=True, livetable=True, verify_write=False, **kwargs):
+    def __init__(self,name, scanplan_type, scanplan_params, dk_window = None, shutter=True, livetable=True, verify_write=False, **kwargs):
         self.name = _clean_md_input(name)
         self.type = 'sp'
         self.scanplan = _clean_md_input(scanplan_type)
@@ -276,6 +276,10 @@ class ScanPlan(XPD):
         else:
             self.md.update({'sp_shutter_control':'external'})
         
+        if not dk_window:
+            dk_window = glbl.dk_window
+        self.md.update({'sp_dk_window': dk_window})
+
         subs=[]
         if livetable:
             subs.append('livetable')
@@ -294,9 +298,6 @@ class ScanPlan(XPD):
             self.md.update({'sp_uid': self._getuid()})
         self._yamify()
     
-    
-
-    #FIXME - make validator clean later
     def _plan_validator(self):
         ''' Validator for ScanPlan object
         
@@ -368,41 +369,6 @@ class Scan(XPD):
         self.md = dict(self.sp.md) # create a new dict copy.
         self.md.update(self.sa.md)
 
-def export_data(root_dir=None, ar_format='gztar', end_beamtime=False):
-    """Create a tarball of all of the data in the user folders.
-
-    This assumes that the root directory is laid out prescribed by DataPath.
-
-    This function will:
-
-      - remove any existing tarball
-      - create a new (timestamped) tarball
-
-    """
-    # FIXME - test purpose
-    if root_dir is None:
-        root_dir = glbl.base
-    #dp = DataPath(root_dir)
-    # remove any existing exports
-    if os.path.isdir(glbl.export_dir):
-        shutil.rmtree(glbl.export_dir)
-    f_name = strftime('data4export_%Y-%m-%dT%H%M')
-    os.makedirs(glbl.export_dir, exist_ok=True)
-    cur_path = os.getcwd()
-    try:
-        os.chdir(glbl.base)
-        print('Compressing your data now. That may take several minutes, please be patient :)' )
-        tar_return = shutil.make_archive(f_name, ar_format, root_dir=glbl.base,
-                base_dir='xpdUser', verbose=1, dry_run=False)
-        shutil.move(tar_return, glbl.export_dir)
-    finally:
-        os.chdir(cur_path)
-    out_file = os.path.join(glbl.export_dir, os.path.basename(tar_return))
-    if not end_beamtime:
-        print('New archive file with name '+out_file+' written.')
-        print('Please copy this to your local computer or external hard-drive')
-    return out_file
-    
 def _clean_name(name,max_length=25):
     '''strips a string, but also removes internal whitespace
     '''

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -21,7 +21,7 @@ import yaml
 from time import strftime
 from xpdacq.utils import _graceful_exit
 from xpdacq.beamtime import Beamtime, XPD, Experiment, Sample, ScanPlan
-from xpdacq.beamtime import export_data, _clean_md_input, _get_hidden_list
+from xpdacq.beamtime import _clean_md_input, _get_hidden_list
 from xpdacq.glbl import glbl
 from shutil import ReadError
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -22,6 +22,7 @@ import numpy as np
 import copy
 import sys
 import uuid
+import warning
 from configparser import ConfigParser
 from xpdacq.utils import _graceful_exit, _RE_state_wrapper
 from xpdacq.glbl import glbl
@@ -173,10 +174,13 @@ def _execute_scans(scan, auto_dark, auto_calibration, light_frame = True, dryrun
 def _auto_dark_collection(scan):
     ''' function to cover automated dark collection logic '''
     light_cnt_time = scan.md['sp_params']['exposure']
-    if 'dk_window' in scan.md['sp_params']:
-        expire_time = scan.md['sp_params']['dk_window']
-    else:
-        expire_time = glbl.dk_window
+    try:
+        expire_time = scan.md['sp_dk_window']
+    except KeyError:
+        # protection, shouldn't happen
+        warnings.warn("It seems your ScanPlan object wasn't instantiated properly."
+                        "This scan will keep going but please check your package after this scan")
+        expire_time = 0
     dark_field_uid = validate_dark(light_cnt_time, expire_time)
     if not dark_field_uid:
         print('''INFO: auto_dark didn't detect a valid dark, so is collecting a new dark frame.

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -22,7 +22,7 @@ import numpy as np
 import copy
 import sys
 import uuid
-import warning
+import warnings
 from configparser import ConfigParser
 from xpdacq.utils import _graceful_exit, _RE_state_wrapper
 from xpdacq.glbl import glbl
@@ -193,8 +193,7 @@ See documentation at http://xpdacq.github.io for more information about controll
             auto_dark_scanplan = ScanPlan('auto_dark_scan',
                 'ct',{'exposure':light_cnt_time}, shutter=False)
         dark_field_uid = dark(scan.sa, auto_dark_scanplan)
-    auto_dark_md_dict = {'sc_dk_field_uid': dark_field_uid,
-                        'sc_dk_window': expire_time}
+    auto_dark_md_dict = {'sc_dk_field_uid': dark_field_uid}
     return auto_dark_md_dict
 
 def _auto_load_calibration_file():
@@ -237,7 +236,7 @@ def prun(sample, scanplan, auto_dark = None, **kwargs):
     scan = Scan(sample, scanplan)
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_isprun':True})
-    if not auto_dark:
+    if auto_dark == None:
         auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = True, light_frame = True, dryrun = False)
     return
@@ -260,7 +259,7 @@ def calibration(sample, scanplan, auto_dark = None, **kwargs):
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_iscalibration':True})
     # only auto_dark is exposed to user
-    if not auto_dark:
+    if auto_dark == None:
         auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = False, light_frame = True, dryrun = False)
     return
@@ -283,7 +282,7 @@ def background(sample, scanplan, auto_dark = None, **kwargs):
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_isbackground':True})
     # only auto_dark is exposed to user
-    if not auto_dark:
+    if auto_dark == None:
         auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = False, light_frame = True, dryrun = False)
     return
@@ -306,7 +305,7 @@ def setupscan(sample, scanplan, auto_dark = None, **kwargs):
     scan.md.update({'sc_usermd':kwargs})
     scan.md.update({'sc_issetupscan':True})
     # only auto_dark is exposed to user
-    if not auto_dark:
+    if auto_dark == None:
         auto_dark = glbl.auto_dark
     _execute_scans(scan, auto_dark, auto_calibration = False, light_frame = True, dryrun = False)
     return

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -178,8 +178,9 @@ def _auto_dark_collection(scan):
         expire_time = scan.md['sp_dk_window']
     except KeyError:
         # protection, shouldn't happen
-        warnings.warn("It seems your ScanPlan object wasn't instantiated properly."
-                        "This scan will keep going but please check your package after this scan")
+        warnings.warn('''It seems your ScanPlan object wasn't instantiated properly.
+                        This may indicate a problem with the current version of the code."
+                        Current scan will keep going but please notify the instrument scientist who can post a bug report''')
         expire_time = 0
     dark_field_uid = validate_dark(light_cnt_time, expire_time)
     if not dark_field_uid:


### PR DESCRIPTION
Make `dk_window` completely an attribute to `ScanPlan` object as discussed in issue 145. Also some cleaning on outdated function during refactoring.

Code now passes `unittest` and simulation mode.
