### PR TITLE
Add `import_userScriptsEtc` function

### DIFF
--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -7,7 +7,7 @@ from xpdacq.glbl import glbl
 import xpdacq.beamtimeSetup as bts
 from xpdacq.beamtimeSetup import _make_clean_env,_start_beamtime,_end_beamtime,_execute_start_beamtime,_check_empty_environment,_load_bt, _execute_end_beamtime, _delete_home_dir_tree
 from xpdacq.beamtime import Beamtime,_get_yaml_list
-from xpdacq.utils import export_userScriptEtc, import_userScriptEtc
+from xpdacq.utils import export_userScriptsEtc, import_userScriptsEtc
 
 class NewBeamtimeTest(unittest.TestCase): 
 
@@ -198,7 +198,7 @@ class NewBeamtimeTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(glbl.yaml_dir))
         self.assertTrue(os.path.isdir(glbl.usrScript_dir))
         # case1 : no files in import_dir, should return nothing
-        self.assertEqual(import_userScriptEtc(), None)
+        self.assertEqual(import_userScriptsEtc(), None)
         # case2 : a tar file with three kind of files, test if it is successfully moved and unpacked
         yaml_name = 'touched.yml'
         py_name = 'touched.py'
@@ -219,7 +219,7 @@ class NewBeamtimeTest(unittest.TestCase):
         shutil.make_archive(tar_name,'tar') # now data should be in xpdUser/Import/
         full_tar_name = os.path.join(src, tar_name + '.tar')
         os.chdir(cwd)
-        moved_list_1 = import_userScriptEtc()
+        moved_list_1 = import_userScriptsEtc()
         for el in tared_list:
             self.assertTrue(el in list(map(lambda x: os.path.basename(x), moved_list_1)))
         # is tar file still there?
@@ -230,7 +230,7 @@ class NewBeamtimeTest(unittest.TestCase):
             open(f_path,'a').close()
         exception_dir_name = os.path.join(src,'touched')
         os.makedirs(exception_dir_name, exist_ok = True) 
-        moved_list_2 = import_userScriptEtc()
+        moved_list_2 = import_userScriptsEtc()
         # grouping file list
         final_list = list(tared_list)
         final_list.extend(untared_list)
@@ -245,14 +245,14 @@ class NewBeamtimeTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(exception_dir_name))
 
 
-    def test_export_userScriptEtc(self):
+    def test_export_userScriptsEtc(self):
         os.makedirs(glbl.usrScript_dir, exist_ok = True)
         os.makedirs(glbl.yaml_dir, exist_ok = True)
         new_script = os.path.join(glbl.usrScript_dir, 'script.py')
         open(new_script, 'a').close()
         new_yaml = os.path.join(glbl.yaml_dir, 'touched.yml')
         open(new_yaml, 'a').close()
-        tar_f_path = export_userScriptEtc()
+        tar_f_path = export_userScriptsEtc()
         shutil.unpack_archive(tar_f_path,glbl.home)
         
         userScript_dir_tail = os.path.split(glbl.usrScript_dir)[1]

--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -5,9 +5,9 @@ import yaml
 from time import strftime
 from xpdacq.glbl import glbl
 import xpdacq.beamtimeSetup as bts
-from xpdacq.beamtimeSetup import _make_clean_env,_start_beamtime,_end_beamtime,_execute_start_beamtime,_check_empty_environment, import_yaml, _load_bt, _execute_end_beamtime, _delete_home_dir_tree
+from xpdacq.beamtimeSetup import _make_clean_env,_start_beamtime,_end_beamtime,_execute_start_beamtime,_check_empty_environment,_load_bt, _execute_end_beamtime, _delete_home_dir_tree
 from xpdacq.beamtime import Beamtime,_get_yaml_list
-from xpdacq.utils import export_userScriptEtc
+from xpdacq.utils import export_userScriptEtc, import_userScriptEtc
 
 class NewBeamtimeTest(unittest.TestCase): 
 
@@ -188,40 +188,55 @@ class NewBeamtimeTest(unittest.TestCase):
         # program places the file in Export directory
         # program gives friendly informational statement to user to email the file to Instr. Scientist.
 
-    def test_import_yaml(self):
+    def test_import_userScript_Etc(self):
         src = glbl.import_dir
-        dst = glbl.yaml_dir
+        dst = [glbl.yaml_dir, glbl.usrScript_dir]
         os.makedirs(src, exist_ok = True)
-        os.makedirs(dst, exist_ok = True)
+        for el in dst:
+            os.makedirs(el, exist_ok = True)
+        self.assertTrue(os.path.isdir(glbl.config_base))
+        self.assertTrue(os.path.isdir(glbl.yaml_dir))
+        self.assertTrue(os.path.isdir(glbl.usrScript_dir))
         # case1 : no files in import_dir, should return nothing
-        self.assertEqual(import_yaml(), None)
-        # case2 : all three kinds of files together, test if they are successfully move and unpackedsuccesfully
+        self.assertEqual(import_userScriptEtc(), None)
+        # case2 : a tar file with three kind of files, test if it is successfully moved and unpacked
         yaml_name = 'touched.yml'
-        tar_name = 'tar_yaml.tar'
+        py_name = 'touched.py'
+        npy_name = 'mask.npy'
+        untared_list = [yaml_name, py_name, npy_name]
         tar_yaml_name = 'tar.yml'
+        tar_py_name = 'tar.py'
+        tar_npy_name = 'tar.npy'
+        tared_list = [tar_yaml_name, tar_py_name, tar_npy_name]
         exception_name = 'yaml.pdf'
-        new_yaml = os.path.join(src, yaml_name)
-        open(new_yaml, 'a').close()
-        new_tar_yaml = os.path.join(src, tar_yaml_name)
-        open(new_tar_yaml, 'a').close()
-        exception_f = os.path.join(src, exception_name)
-        open(exception_f, 'a').close()
+        # create archive file
+        for el in tared_list:
+            f_path = os.path.join(src, el)
+            open(f_path,'a').close()
         cwd = os.getcwd()
         os.chdir(src) # inevitable step for compression
-        (root, ext) = os.path.splitext(tar_name)
-        shutil.make_archive(root,'tar') # now data should be in xpdUser/Import/
+        tar_name = 'HappyMeal'
+        shutil.make_archive(tar_name,'tar') # now data should be in xpdUser/Import/
+        full_tar_name = os.path.join(src, tar_name + '.tar')
         os.chdir(cwd)
-        os.remove(new_tar_yaml)
-        self.assertEqual(import_yaml(), [tar_name, yaml_name])
-        import_yaml()
-        # confirm valied files are successfully moved and original copy is flushed
-        self.assertTrue(yaml_name in os.listdir(dst))
-        self.assertTrue(tar_yaml_name in os.listdir(dst))
-        self.assertFalse(os.path.isfile(new_yaml))
-        self.assertFalse(os.path.isfile(new_tar_yaml))
-        # confirm unrecongnized file is left in import dir
-        self.assertTrue(os.path.isfile(exception_f))
-
+        print(os.listdir(src))
+        moved_list_1 = import_userScriptEtc()
+        for el in tared_list:
+            self.assertTrue(el in list(map(lambda x: os.path.basename(x), moved_list_1)))
+        # is tar file still there?
+        print(os.listdir(src))
+        print('full tar name = {}'.format(full_tar_name))
+        self.assertTrue(os.path.isfile(full_tar_name))
+        # case 3 : both tared file and individual files appear in Import/
+        for el in untared_list:
+            f_path = os.path.join(src, el)
+            open(f_path,'a').close()
+        moved_list_2 = import_userScriptEtc()
+        tared_list.extend(untared_list)
+        for el in tared_list:
+            self.assertTrue(el in list(map(lambda x: os.path.basename(x), moved_list_2)))
+        # is tar file still there?
+        self.assertTrue(os.path.isfile(full_tar_name))
 
     def test_export_userScriptEtc(self):
         os.makedirs(glbl.usrScript_dir, exist_ok = True)

--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -203,12 +203,12 @@ class NewBeamtimeTest(unittest.TestCase):
         yaml_name = 'touched.yml'
         py_name = 'touched.py'
         npy_name = 'mask.npy'
-        untared_list = [yaml_name, py_name, npy_name]
+        exception_name = 'yaml.pdf'
+        untared_list = [yaml_name, py_name, npy_name, exception_name]
         tar_yaml_name = 'tar.yml'
         tar_py_name = 'tar.py'
         tar_npy_name = 'tar.npy'
         tared_list = [tar_yaml_name, tar_py_name, tar_npy_name]
-        exception_name = 'yaml.pdf'
         # create archive file
         for el in tared_list:
             f_path = os.path.join(src, el)
@@ -219,24 +219,31 @@ class NewBeamtimeTest(unittest.TestCase):
         shutil.make_archive(tar_name,'tar') # now data should be in xpdUser/Import/
         full_tar_name = os.path.join(src, tar_name + '.tar')
         os.chdir(cwd)
-        print(os.listdir(src))
         moved_list_1 = import_userScriptEtc()
         for el in tared_list:
             self.assertTrue(el in list(map(lambda x: os.path.basename(x), moved_list_1)))
         # is tar file still there?
-        print(os.listdir(src))
-        print('full tar name = {}'.format(full_tar_name))
         self.assertTrue(os.path.isfile(full_tar_name))
-        # case 3 : both tared file and individual files appear in Import/
+        # case 3 : tared file, individual files and unexcepted file/dir appear in Import/
         for el in untared_list:
             f_path = os.path.join(src, el)
             open(f_path,'a').close()
+        exception_dir_name = os.path.join(src,'touched')
+        os.makedirs(exception_dir_name, exist_ok = True) 
         moved_list_2 = import_userScriptEtc()
-        tared_list.extend(untared_list)
-        for el in tared_list:
+        # grouping file list
+        final_list = list(tared_list)
+        final_list.extend(untared_list)
+        final_list.remove(exception_name)
+        for el in final_list:
             self.assertTrue(el in list(map(lambda x: os.path.basename(x), moved_list_2)))
         # is tar file still there?
         self.assertTrue(os.path.isfile(full_tar_name))
+        # is .pdf file still there?
+        self.assertTrue(os.path.isfile(os.path.join(src, exception_name)))
+        # is directory still there?
+        self.assertTrue(os.path.isdir(exception_dir_name))
+
 
     def test_export_userScriptEtc(self):
         os.makedirs(glbl.usrScript_dir, exist_ok = True)

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -222,38 +222,5 @@ def _execute_start_beamtime(piname,safn,explist,wavelength=None,home_dir=None):
     sc30 = ScanPlan('ct30s','ct',{'exposure':30.0})
     return bt
 
-def import_yaml():
-    '''
-    import user pre-defined files from ~/xpdUser/Import
-
-    Files can be compreesed or .yml, once imported, bt.list() should show updated acquire object list
-    '''
-    src_dir = glbl.import_dir
-    dst_dir = glbl.yaml_dir
-    f_list = os.listdir(src_dir)
-    if len(f_list) == 0:
-        print('INFO: There is no pre-defined user objects in {}'.format(src_dir))
-        return 
-    # two possibilites: .yml or compressed files; shutil should handle all compressed cases
-    moved_f_list = []
-    for f in f_list:
-        full_path = os.path.join(src_dir, f)
-        (root, ext) = os.path.splitext(f)
-        if ext == '.yml':
-            shutil.copy(full_path, dst_dir)
-            moved_f_list.append(f)
-            # FIXME - do we want user confirmation?
-            os.remove(full_path)
-        else:
-            try:
-                shutil.unpack_archive(full_path, dst_dir)
-                moved_f_list.append(f)
-                # FIXME - do we want user confirmation?
-                os.remove(full_path)
-            except ReadError:
-                print('Unrecongnized file type {} is found inside {}'.format(f, src_dir))
-                pass
-    return moved_f_list
-
 if __name__ == '__main__':
     print(glbl.home)

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -151,7 +151,9 @@ def import_userScriptsEtc():
                 pass
         else:
             # don't expect user to have directory
-            print('Expect a file but get a directory {}. Did you properly archive it?'.format(f_name))
+            print('''I can only import files, not directories. Please place in the import directory either:
+                (1) all your files such as scripts, masks and xpdAcq object yaml files or 
+                (2) a tar or zipped-tar archive file containing those files.'''.format(f_name))
             failure_list.append(f_name)
             pass
     if failure_list:
@@ -166,6 +168,6 @@ def _copy_and_delete(f_name, src_full_path, dst_dir):
         os.remove(src_full_path)
         return dst_name
     else:
-        print('We have problem moving {} it will still leave at xpdUser/Import/'.format(f_name))
+        print('We had a problem moving {}. Most likely it is not a supported file type (e.g., .yml, .py, .npy, .tar, .gz). It will not be available for use in xpdAcq, but it will be left in the xpdUser/Import/ directory'.format(f_name))
         return
 

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -168,6 +168,8 @@ def _copy_and_delete(f_name, src_full_path, dst_dir):
         os.remove(src_full_path)
         return dst_name
     else:
-        print('We had a problem moving {}. Most likely it is not a supported file type (e.g., .yml, .py, .npy, .tar, .gz). It will not be available for use in xpdAcq, but it will be left in the xpdUser/Import/ directory'.format(f_name))
+        print('''We had a problem moving {}.
+                Most likely it is not a supported file type (e.g., .yml, .py, .npy, .tar, .gz).
+                It will not be available for use in xpdAcq, but it will be left in the xpdUser/Import/ directory'''.            format(f_name))
         return
 

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -68,7 +68,7 @@ def _RE_state_wrapper(RE_obj):
         else:
             print('please renter your input')
 
-def export_userScriptEtc():
+def export_userScriptsEtc():
     """ function that exports user defined objects/scripts stored under config_base and userScript
         
         it will create a uncompressed tarball inside xpdUser/Export
@@ -81,7 +81,7 @@ def export_userScriptEtc():
     F_EXT = '.tar'
     root_dir = glbl.home
     os.chdir(root_dir)
-    f_name = strftime('userScriptEtc_%Y-%m-%dT%H%M') + F_EXT
+    f_name = strftime('userScriptsEtc_%Y-%m-%dT%H%M') + F_EXT
     # extra work to avoid comple directory structure in tarball
     tar_f_name = os.path.join(glbl.home, f_name)
     export_dir_list = list(map(lambda x: os.path.basename(x), glbl._export_tar_dir))
@@ -93,21 +93,28 @@ def export_userScriptEtc():
         return archive_path
     else:
         _graceful_exit('Did you accidentally change write privilege to {}'.format(glbl.home))
-        print('Please check your setting and try `export_userScriptEtc()` again at command prompt')
+        print('Please check your setting and try `export_userScriptsEtc()` again at command prompt')
         return
 
-def import_userScriptEtc():
-    '''
-    import beamtime control files predefined by users from xpdUser/Import
+def import_userScriptsEtc():
+    '''Import user files that have been placed in xpdUser/Import for use by xpdAcq
 
-    Files could be archived files or indivisual script(.py), mask(.npy) or yaml(.yml) files.
-    Once files are imported, they will be deleted but user can use `export_userScriptEtc` to revert them.
+    Allowed files are python user-script files (extension .py), detector-image mask files (.npy) or files containing xpdAcq objects (extension .yml).
+    Files created by running export_userScriptsEtc() are also allowed.  Unallowed files (anything not in the previous list) will be ignored. 
+
+    After import, all files in the xpdUser/import directory will be deleted
+    The user can run `export_userScriptsEtc` to revert them.
+
+    Return
+    ------
+        moved_list : list
+        a list of file names that have been moved successfully
     '''
     _f_ext_dst_dict = ['py', 'npy', 'yml']
     src_dir = glbl.import_dir
     f_list = os.listdir(src_dir)
     if len(f_list) == 0:
-        print('INFO: There is no pre-defined user objects in {}'.format(src_dir))
+        print('INFO: There is no predefined user objects in {}'.format(src_dir))
         return 
     # unpack every archived file in Import/
     for f in f_list:
@@ -143,7 +150,7 @@ def import_userScriptEtc():
                 failure_list.append(f_name)
                 pass
         else:
-            # don't expect user to see have directory
+            # don't expect user to have directory
             print('Expect a file but get a directory {}. Did you properly archive it?'.format(f_name))
             failure_list.append(f_name)
             pass

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -94,3 +94,37 @@ def export_userScriptEtc():
         _graceful_exit('Did you accidentally change write privilege to {}'.format(glbl.home))
         print('Please check your setting and try `export_userScriptEtc()` again at command prompt')
         return
+
+def import_yaml():
+    '''
+    import user pre-defined files from ~/xpdUser/Import
+
+    Files can be compreesed or .yml, once imported, bt.list() should show updated acquire object list
+    '''
+    src_dir = glbl.import_dir
+    dst_dir = glbl.yaml_dir
+    f_list = os.listdir(src_dir)
+    if len(f_list) == 0:
+        print('INFO: There is no pre-defined user objects in {}'.format(src_dir))
+        return 
+    # two possibilites: .yml or compressed files; shutil should handle all compressed cases
+    moved_f_list = []
+    for f in f_list:
+        full_path = os.path.join(src_dir, f)
+        (root, ext) = os.path.splitext(f)
+        if ext == '.yml':
+            shutil.copy(full_path, dst_dir)
+            moved_f_list.append(f)
+            # FIXME - do we want user confirmation?
+            os.remove(full_path)
+        else:
+            try:
+                shutil.unpack_archive(full_path, dst_dir)
+                moved_f_list.append(f)
+                # FIXME - do we want user confirmation?
+                os.remove(full_path)
+            except ReadError:
+                print('Unrecongnized file type {} is found inside {}'.format(f, src_dir))
+                pass
+    return moved_f_list
+

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+from shutil import ReadError
 import tarfile as tar
 from time import strftime
 
@@ -112,14 +113,15 @@ def import_userScriptEtc():
     for f in f_list:
         try:
             # shutil should handle all compressed cases
-            shutil.unpack_archive(src_full_path, src_dir)
+            tar_full_path = os.path.join(src_dir, f)
+            shutil.unpack_archive(tar_full_path, src_dir)
         except ReadError:
             pass
     f_list = os.listdir(src_dir) # new f_list, after unpack
     moved_list = []
     failure_list = []
     for f_name in f_list:
-        if os.path.isfile(f_name):
+        if os.path.isfile(os.path.join(src_dir, f_name)):
             src_full_path = os.path.join(src_dir, f_name)
             (root, ext) = os.path.splitext(f_name)
             if ext == '.yml':
@@ -134,6 +136,8 @@ def import_userScriptEtc():
                 dst_dir = glbl.config_base
                 npy_dst_name = _copy_and_delete(f_name, src_full_path, dst_dir) 
                 moved_list.append(npy_dst_name)
+            elif ext in ('.tar', '.zip', '.gztar'):
+                pass
             else:
                 print('{} is not a supported format'.format(f_name))
                 failure_list.append(f_name)
@@ -143,7 +147,8 @@ def import_userScriptEtc():
             print('Expect a file but get a directory {}. Did you properly archive it?'.format(f_name))
             failure_list.append(f_name)
             pass
-    print('Finished importing. Failed to move {} but they will leave in Import/'.format(failure_list))
+    if failure_list:
+        print('Finished importing. Failed to move {} but they will leave in Import/'.format(failure_list))
     return moved_list
 
 def _copy_and_delete(f_name, src_full_path, dst_dir):
@@ -151,9 +156,9 @@ def _copy_and_delete(f_name, src_full_path, dst_dir):
     dst_name = os.path.join(dst_dir, f_name) 
     if os.path.isfile(dst_name):
         print('{} has been successfully moved to {}'.format(f_name, dst_dir))
-        os.remove(full_path)
+        os.remove(src_full_path)
         return dst_name
     else:
-        print('We have problem moving {}. It will still leave at xpdUser/Import/'.format(f_name))
+        print('We have problem moving {} it will still leave at xpdUser/Import/'.format(f_name))
         return
 


### PR DESCRIPTION
fix #2.

function imports files sit in `xpdUser/Import/` and move each of them to different destination based on file extension. Unsupported files and files which are not successifully moved will stay in `xpdUser/Import/`.
Code now passes `unittest`.