### PR TITLE
add scan parser

### DIFF
--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -219,4 +219,20 @@ class NewExptTest(unittest.TestCase):
         self.assertEqual(self.bt.md['bt_wavelength'],wavelength)
         self.assertEqual(self.bt.name,'bt')
         self.assertEqual(self.bt.md['bt_piLast'],'test')
-        
+       
+    def test_Scan_validator(self):
+        #########################################################
+        # Note: bt.list() so far is populated with l-user list
+        #       bt.get(2) -> sa,'l-user' ; bt.get(5) -> sp, 'ct1s'
+        #       bt.list() goes to 8
+        ##########################################################
+        # incorrect assignments -> str
+        self.assertRaises(SystemExit, lambda: Scan._object_parser(Scan,'blahblah','sa'))
+        self.assertRaises(SystemExit, lambda: Scan._object_parser(Scan,'ct157s','sp'))
+        # incorrect assignments -> ind
+        self.assertRaises(SystemExit, lambda: Scan._object_parser(Scan,100,'sp'))
+        self.assertRaises(SystemExit, lambda: Scan._object_parser(Scan,250,'sa'))
+        # incorrect object type from 3 kind of assignments
+        self.assertRaises(TypeError, lambda: Scan(self.bt.get(1), self.bt.get(5))) # give Beamtime but not Sample
+        self.assertRaises(TypeError, lambda: Scan(1, 'ct10s')) # give Beamtime but not Sample
+        self.assertRaises(TypeError, lambda: Scan(8, 5)) # give two ScanPlan

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -25,7 +25,6 @@ import copy
 from xpdacq.glbl import glbl
 from xpdacq.utils import _graceful_exit
 
-#datapath = glbl.dp()
 home_dir = glbl.home
 yaml_dir = glbl.yaml_dir
 
@@ -144,8 +143,7 @@ class XPD:
         fo = open(hname, 'w')
         yaml.dump(hidden_list, fo)
         return hidden_list
-
-    # test at XPD
+    
     def _init_dark_scan_list(self):
         dark_scan_list = []
         with open(glbl.dk_yaml,'w') as f:
@@ -295,9 +293,6 @@ class ScanPlan(XPD):
             self.md.update({'sp_uid': self._getuid()})
         self._yamify()
     
-    
-
-    #FIXME - make validator clean later
     def _plan_validator(self):
         ''' Validator for ScanPlan object
         
@@ -376,30 +371,29 @@ class Scan(XPD):
         '''a priviate parser for arbitrary object input
         ''' 
         FEXT = '.yml'
-        e = '''We can not find your {} object {}. Please do bt.list() to make sure you type right name'''.format(obj_type, input_obj)
+        e_msg_str_type = '''We can not find your "{} object {}". Please do bt.list() to make sure you type right name'''.format(obj_type, input_obj)
+        e_msg_ind_type = '''We can not find object with index {}. Please do bt.list() to make sure you type correct index'''.format(input_obj)
         if isinstance(input_obj, str):
             yml_list = _get_yaml_list()
-            try:
-                while yml_list:
-                    el = yml_list.pop()
-                    (yml_type, name) = el.split('_', maxsplit=1)
-                    print('({}, {})'.format(yml_type, name))
-                    print('type = ({})'.format(type(yml_type), type(name)))
-                    if yml_type == obj_type and name == input_obj+FEXT:
-                        f_name = os.path.join(glbl.yaml_dir, el)
-                        with open(f_name, 'r') as fout:
-                            output_obj = yaml.load(fout)
-                        return output_obj
-            finally:
-                    # exit out if we can't find proper object
-                    _graceful_exit(e)
+            output_obj = None
+            while yml_list:
+                el = yml_list.pop()
+                (yml_type, name) = el.split('_', maxsplit=1)
+                if yml_type == obj_type and name == input_obj + FEXT:
+                    f_name = os.path.join(glbl.yaml_dir, el)
+                    with open(f_name, 'r') as fout:
+                        output_obj = yaml.load(fout)
+                    return output_obj
+            # if still can't find it after going over entire list
+            if not output_obj:
+                _graceful_exit(e_msg_str_type)
         elif isinstance(input_obj, int):
             try:
                 return self.get(input_obj)
             except IndexError:
-                _graceful_exit('''We can not find object with index {}. Please do bt.list() to make sure you type correct index'''.format(input_obj))
+                _graceful_exit(e_msg_ind_type)
         else:
-            #FIXME
+            #FIXME define xpdacq.beamtime.<class> type
             return input_obj
 
 def export_data(root_dir=None, ar_format='gztar', end_beamtime=False):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -362,7 +362,7 @@ class Scan(XPD):
     1) bt.get(<object_index>), eg. Scan(bt.get(2), bt.get(5))
     2) name of acquire object, eg. Scan('my_experiment', 'ct1s')
     3) index to acquire object, eg. Scan(2,5)
-    All of above assigning methods can be used in a mix way
+    All of above assigning methods can be used in a mix way.
 
     Parameters:
     -----------
@@ -398,21 +398,22 @@ class Scan(XPD):
             # note: el.split('_', maxsplit=1) = (yml_type, yml_name)
             yml_name_found = [el for el in yml_list if el.split('_', maxsplit=1)[0] == expect_yml_type
                             and el.split('_', maxsplit=1)[1] == input_obj+FEXT]
-            if not yml_name_found:
+            if yml_name_found:
+                with open(os.path.join(glbl.yaml_dir, yml_name_found[-1]), 'r') as f_out:
+                    output_obj = yaml.load(f_out)
+                return output_obj
+            else:
                 # if still can't find it after going over entire list
-                _graceful_exit(e_msg_str_type)
-            with open(os.path.join(glbl.yaml_dir, yml_name_found[-1]), 'r') as f_out:
-                output_obj = yaml.load(f_out)
-            return output_obj
+                sys.exit(_graceful_exit(e_msg_str_type))
         elif isinstance(input_obj, int):
             try:
                 output_obj = self.get(input_obj)
                 return output_obj
             except IndexError:
-                _graceful_exit(e_msg_ind_type)
+                sys.exit(_graceful_exit(e_msg_ind_type))
         else:
             # let xpdAcq object validator deal with other cases
-            pass
+            return input_obj
     
     def _acq_object_validator(self, input_obj, expect_class):
         ''' filter of object class to Scan

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -164,8 +164,6 @@ def _execute_scans(scan, auto_dark, auto_calibration, light_frame = True, dryrun
             scan.md.update(auto_load_calibration_dict)
     if light_frame and scan.sp.shutter:
         _open_shutter()
-    print('LIGHT FRAME CALLED')
-    print('scan.md before light frame'.format(scan.md))
     _unpack_and_run(scan, dryrun, **kwargs)
     # always close a shutter after scan, if shutter is in control
     if scan.sp.shutter:
@@ -173,7 +171,6 @@ def _execute_scans(scan, auto_dark, auto_calibration, light_frame = True, dryrun
     return
 
 def _auto_dark_collection(scan):
-    print('CALLED AUTO DARK')
     ''' function to cover automated dark collection logic '''
     light_cnt_time = scan.md['sp_params']['exposure']
     if 'dk_window' in scan.md['sp_params']:

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -164,6 +164,8 @@ def _execute_scans(scan, auto_dark, auto_calibration, light_frame = True, dryrun
             scan.md.update(auto_load_calibration_dict)
     if light_frame and scan.sp.shutter:
         _open_shutter()
+    print('LIGHT FRAME CALLED')
+    print('scan.md before light frame'.format(scan.md))
     _unpack_and_run(scan, dryrun, **kwargs)
     # always close a shutter after scan, if shutter is in control
     if scan.sp.shutter:
@@ -171,6 +173,7 @@ def _execute_scans(scan, auto_dark, auto_calibration, light_frame = True, dryrun
     return
 
 def _auto_dark_collection(scan):
+    print('CALLED AUTO DARK')
     ''' function to cover automated dark collection logic '''
     light_cnt_time = scan.md['sp_params']['exposure']
     if 'dk_window' in scan.md['sp_params']:
@@ -231,11 +234,14 @@ def prun(sample, scanplan, auto_dark = None, **kwargs):
         option of automated dark collection. Default is True to allow collect dark automatically during scans
     '''
     scan = Scan(sample, scanplan)
-    scan.md.update({'sc_usermd':kwargs})
-    scan.md.update({'sc_isprun':True})
-    if not auto_dark:
-        auto_dark = glbl.auto_dark
-    _execute_scans(scan, auto_dark, auto_calibration = True, light_frame = True, dryrun = False)
+    if scan:
+        scan.md.update({'sc_usermd':kwargs})
+        scan.md.update({'sc_isprun':True})
+        if not auto_dark:
+            auto_dark = glbl.auto_dark
+        _execute_scans(scan, auto_dark, auto_calibration = True, light_frame = True, dryrun = False)
+    else:
+        _graceful_exit('Scan object did not instantiate properly')
     return
 
 def calibration(sample, scanplan, auto_dark = None, **kwargs):


### PR DESCRIPTION
Add logic of parsing object handed to `Scan` class. This PR is for #172.
Following contents are from docstring
````
+    Scan class supports following ways of assigning Sample, ScanPlan objects:
+    1) bt.get(<object_index>), eg. Scan(bt.get(2), bt.get(5))
+    2) name of acquire object, eg. Scan('my_experiment', 'ct1s')
+    3) index to acquire object, eg. Scan(2,5)
+    All of above assigning methods can be used in a mix way.
````
Now code passes `unittest` and simulation test.