### PR TITLE
Refactor ScanPlan class

### DIFF
--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -30,7 +30,7 @@ class NewExptTest(unittest.TestCase):
         with open(self.saffile, 'w') as fo:
             yaml.dump(loadinfo,fo)
         self.bt = _start_beamtime(self.saf_num,home_dir=self.home_dir)     
-        self.stbt_list = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sp_ct.1s.yml','sp_ct.5s.yml','sp_ct1s.yml','sp_ct5s.yml','sp_ct10s.yml','sp_ct30s.yml']
+        self.stbt_list = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sp_ct_0.1.yml','sp_ct_0.5.yml','sp_ct_1.yml','sp_ct_5.yml','sp_ct_10.yml','sp_ct_30.yml']
 
     def tearDown(self):
         os.chdir(self.base_dir)
@@ -163,24 +163,24 @@ class NewExptTest(unittest.TestCase):
         self.assertEqual(newobjlist,self.stbt_list+['ex_myexp.yml','sa_mysample.yml','sa_yoursample.yml'])
 
     def test_make_scanPlan(self):
-        self.sp = ScanPlan('myScan','ct',{'exposure':1.0})
+        self.sp = ScanPlan('ct',{'exposure':1.0})
         self.assertIsInstance(self.sp,ScanPlan)
         self.assertEqual(self.sp.md['sp_params'],{'exposure':1.0})
         uid1 = self.sp.md['sp_uid']
         newobjlist = _get_yaml_list()
-        self.assertEqual(newobjlist,self.stbt_list+['sp_myScan.yml'])
-        self.sp2 = ScanPlan(' your scan','ct',{'exposure':1.0})
-        self.assertEqual(self.sp2.md['sp_name'],'your scan')
+        self.assertEqual(newobjlist,self.stbt_list+['sp_ct_1.yml'])
+        self.sp2 = ScanPlan('ct',{'exposure':1.5})
+        self.assertEqual(self.sp2.md['sp_name'],'ct_1.5')
         uid2 = self.sp2.md['sp_uid']
         self.assertNotEqual(uid1,uid2)
         newobjlist = _get_yaml_list()
-        self.assertEqual(newobjlist,self.stbt_list+['sp_myScan.yml','sp_yourscan.yml'])
-        self.sp3 = ScanPlan(' your scan','ct',{'exposure':1.0})
-        self.assertEqual(self.sp3.md['sp_name'],'your scan')
+        self.assertEqual(newobjlist,self.stbt_list+['sp_ct_1.yml','sp_ct_1.5.yml'])
+        self.sp3 = ScanPlan('ct',{'exposure':2.0})
+        self.assertEqual(self.sp3.md['sp_name'],'ct_2')
         uid3 = self.sp3.md['sp_uid']
         self.assertEqual(uid2,uid3)
         # and one that fails the validator
-        self.assertRaises(SystemExit,lambda: ScanPlan(' your scan','ct',{'exposur':1.0}))
+        self.assertRaises(SystemExit,lambda: ScanPlan('ct',{'exposur':1.0}))
 
 
     def test_hide(self):

--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -18,7 +18,7 @@ class NewExptTest(unittest.TestCase):
         if os.path.isdir(self.home_dir):
             shutil.rmtree(self.home_dir)
         if os.path.isdir(self.config_dir):
-            shutil.rmtree(self.config_dir)   
+            shutil.rmtree(self.config_dir)
         os.makedirs(self.config_dir, exist_ok=True)
         self.PI_name = 'Billinge '
         self.saf_num = 234
@@ -261,3 +261,25 @@ class NewExptTest(unittest.TestCase):
         self.assertEqual(sp.name, 'ct_5_nS')
         sp = ScanPlan('ct_5', shutter=True)
         self.assertEqual(sp.name, 'ct_5')
+
+    def test_ScanPlan_longform(self):
+        # test creation
+        self.assertRaises(TypeError, lambda: ScanPlan())
+        # test sp_name
+        sp1 = ScanPlan('ct',{'exposure':0.5})
+        self.assertEqual(sp1.name, 'ct_0.5')
+        sp2 = ScanPlan('tseries',{'exposure':0.5, 'num':5, 'delay':2.5})
+        self.assertEqual(sp2.name, 'tseries_0.5_2.5_5')
+        sp3 = ScanPlan('Tramp',{'exposure':0.5, 'endingT':200, 'startingT':300, 'Tstep':2})
+        self.assertEqual(sp3.name, 'Tramp_5_300_200_2')
+        # test sp_params values
+        self.assertEqual(0.5, sp1.sp_params['exposure'])
+
+        self.assertEqual(0.5, sp2.sp_params['exposure'])
+        self.assertEqual(5, sp2.sp_params['num'])
+        self.assertEqual(2.5, sp2.sp_params['delay'])
+
+        self.assertEqual(0.5, sp3.sp_params['exposure'])
+        self.assertEqual(200, sp3.sp_params['endingT'])
+        self.assertEqual(300, sp3.sp_params['startingT'])
+        self.assertEqual(2, sp3.sp_params['Tstep'])

--- a/tests/test_beamtime.py
+++ b/tests/test_beamtime.py
@@ -29,7 +29,7 @@ class NewExptTest(unittest.TestCase):
         loadinfo = {'saf number':self.saf_num,'PI last name':self.PI_name,'experimenter list':self.experimenters}
         with open(self.saffile, 'w') as fo:
             yaml.dump(loadinfo,fo)
-        self.bt = _start_beamtime(self.saf_num,home_dir=self.home_dir)     
+        self.bt = _start_beamtime(self.saf_num,home_dir=self.home_dir)
         self.stbt_list = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sp_ct_0.1.yml','sp_ct_0.5.yml','sp_ct_1.yml','sp_ct_5.yml','sp_ct_10.yml','sp_ct_30.yml']
 
     def tearDown(self):
@@ -37,7 +37,7 @@ class NewExptTest(unittest.TestCase):
         if os.path.isdir(self.home_dir):
             shutil.rmtree(self.home_dir)
         if os.path.isdir(os.path.join(self.base_dir,'xpdConfig')):
-            shutil.rmtree(os.path.join(self.base_dir,'xpdConfig'))        
+            shutil.rmtree(os.path.join(self.base_dir,'xpdConfig'))
 
     def test_clean_name(self):
     	# make sure yaml dir and bt object exists
@@ -163,20 +163,20 @@ class NewExptTest(unittest.TestCase):
         self.assertEqual(newobjlist,self.stbt_list+['ex_myexp.yml','sa_mysample.yml','sa_yoursample.yml'])
 
     def test_make_scanPlan(self):
-        self.sp = ScanPlan('ct',{'exposure':1.0})
+        self.sp = ScanPlan('ct',{'exposure':0.7})
         self.assertIsInstance(self.sp,ScanPlan)
-        self.assertEqual(self.sp.md['sp_params'],{'exposure':1.0})
+        self.assertEqual(self.sp.md['sp_params'],{'exposure':0.7})
         uid1 = self.sp.md['sp_uid']
         newobjlist = _get_yaml_list()
-        self.assertEqual(newobjlist,self.stbt_list+['sp_ct_1.yml'])
+        self.assertEqual(newobjlist,self.stbt_list+['sp_ct_0.7.yml'])
         self.sp2 = ScanPlan('ct',{'exposure':1.5})
         self.assertEqual(self.sp2.md['sp_name'],'ct_1.5')
         uid2 = self.sp2.md['sp_uid']
         self.assertNotEqual(uid1,uid2)
         newobjlist = _get_yaml_list()
-        self.assertEqual(newobjlist,self.stbt_list+['sp_ct_1.yml','sp_ct_1.5.yml'])
-        self.sp3 = ScanPlan('ct',{'exposure':2.0})
-        self.assertEqual(self.sp3.md['sp_name'],'ct_2')
+        self.assertEqual(newobjlist,self.stbt_list+['sp_ct_0.7.yml','sp_ct_1.5.yml'])
+        self.sp3 = ScanPlan('ct',{'exposure':1.5})
+        self.assertEqual(self.sp3.md['sp_name'],'ct_1.5')
         uid3 = self.sp3.md['sp_uid']
         self.assertEqual(uid2,uid3)
         # and one that fails the validator
@@ -266,20 +266,20 @@ class NewExptTest(unittest.TestCase):
         # test creation
         self.assertRaises(TypeError, lambda: ScanPlan())
         # test sp_name
-        sp1 = ScanPlan('ct',{'exposure':0.5})
-        self.assertEqual(sp1.name, 'ct_0.5')
-        sp2 = ScanPlan('tseries',{'exposure':0.5, 'num':5, 'delay':2.5})
-        self.assertEqual(sp2.name, 'tseries_0.5_2.5_5')
-        sp3 = ScanPlan('Tramp',{'exposure':0.5, 'endingT':200, 'startingT':300, 'Tstep':2})
-        self.assertEqual(sp3.name, 'Tramp_5_300_200_2')
+        self.sp1 = ScanPlan('ct',{'exposure':0.5})
+        self.assertEqual(self.sp1.name, 'ct_0.5')
+        self.sp2 = ScanPlan('tseries',{'exposure':0.5, 'num':5, 'delay':2.5})
+        self.assertEqual(self.sp2.name, 'tseries_0.5_2.5_5')
+        self.sp3 = ScanPlan('Tramp',{'exposure':0.8, 'endingT':200, 'startingT':300, 'Tstep':2})
+        self.assertEqual(self.sp3.name, 'Tramp_0.8_300_200_2')
         # test sp_params values
-        self.assertEqual(0.5, sp1.sp_params['exposure'])
+        self.assertEqual(0.5, self.sp1.sp_params['exposure'])
 
-        self.assertEqual(0.5, sp2.sp_params['exposure'])
-        self.assertEqual(5, sp2.sp_params['num'])
-        self.assertEqual(2.5, sp2.sp_params['delay'])
+        self.assertEqual(0.5, self.sp2.sp_params['exposure'])
+        self.assertEqual(5, self.sp2.sp_params['num'])
+        self.assertEqual(2.5, self.sp2.sp_params['delay'])
 
-        self.assertEqual(0.5, sp3.sp_params['exposure'])
-        self.assertEqual(200, sp3.sp_params['endingT'])
-        self.assertEqual(300, sp3.sp_params['startingT'])
-        self.assertEqual(2, sp3.sp_params['Tstep'])
+        self.assertEqual(0.8, self.sp3.sp_params['exposure'])
+        self.assertEqual(200, self.sp3.sp_params['endingT'])
+        self.assertEqual(300, self.sp3.sp_params['startingT'])
+        self.assertEqual(2, self.sp3.sp_params['Tstep'])

--- a/tests/test_beamtimeSetup.py
+++ b/tests/test_beamtimeSetup.py
@@ -124,7 +124,7 @@ class NewBeamtimeTest(unittest.TestCase):
         self.assertEqual(bt.md['bt_wavelength'],None)
         os.chdir(self.base_dir)
         newobjlist = _get_yaml_list()
-        strtScnLst = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sp_ct.1s.yml','sp_ct.5s.yml','sp_ct1s.yml','sp_ct5s.yml','sp_ct10s.yml','sp_ct30s.yml']
+        strtScnLst = ['bt_bt.yml','ex_l-user.yml','sa_l-user.yml','sp_ct_0.1.yml','sp_ct_0.5.yml','sp_ct_1.yml','sp_ct_5.yml','sp_ct_10.yml','sp_ct_30.yml']
         self.assertEqual(newobjlist,strtScnLst)
     
     def test_end_beamtime(self):

--- a/tests/test_scans.py
+++ b/tests/test_scans.py
@@ -45,8 +45,8 @@ class NewScanTest(unittest.TestCase):
             shutil.rmtree(os.path.join(glbl.base,'xpdConfig'))
 
     def test_auto_dark_collection(self):
-        self.sp_set_dk_window = ScanPlan('unittest_count','ct', {'exposure': 0.1}, dk_window = 25575, shutter = False)
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sp_set_dk_window = ScanPlan('ct', {'exposure': 0.1}, dk_window = 25575, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)
         self.sc_set_dk_window = Scan(self.sa, self.sp_set_dk_window)
         self.sc = Scan(self.sa, self.sp)
         auto_dark_md_dict_set_dk_window = _auto_dark_collection(self.sc_set_dk_window)
@@ -58,7 +58,7 @@ class NewScanTest(unittest.TestCase):
         self.assertEqual(25575, self.sp_set_dk_window.md['sp_dk_window'])
 
     def test_auto_load_calibration(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)
         # no config file in xpdUser/config_base
         auto_calibration_md_dict = _auto_load_calibration_file()
         self.assertIsNone(auto_calibration_md_dict)
@@ -98,7 +98,7 @@ class NewScanTest(unittest.TestCase):
         self.assertEqual(modified_auto_calibration_md_dict['sc_calibration_parameters']['Others']['avgmask'], 'False')
 
     def test_new_prun_with_auto_dark_and_auto_calibration(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1, 'dk_window':32767}, dk_window = 32767, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1, 'dk_window':32767}, dk_window = 32767, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         cfg_f_name = 'srxconfig.cfg'
@@ -122,7 +122,7 @@ class NewScanTest(unittest.TestCase):
         self.assertFalse('sc_isprun' in self.sp.md)
 
     def test_new_prun_no_auto_dark_but_auto_calibration(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1, 'dk_window':32767}, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1, 'dk_window':32767}, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         cfg_f_name = 'srxconfig.cfg'
@@ -145,7 +145,7 @@ class NewScanTest(unittest.TestCase):
 
     def test_prun_with_bleusky_plan(self):
         cc = Count([det], 2)
-        self.sp = ScanPlan('unittest_bs','bluesky', {'bluesky_plan':cc},
+        self.sp = ScanPlan('bluesky', {'bluesky_plan':cc},
                 shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
@@ -171,7 +171,7 @@ class NewScanTest(unittest.TestCase):
         self.assertFalse('sc_isprun' in self.sp.md)
 
     def test_dark(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         cfg_f_name = 'srxconfig.cfg'
@@ -193,7 +193,7 @@ class NewScanTest(unittest.TestCase):
         self.assertFalse('sc_isdark' in self.sp.md)
 
     def test_calibration(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         calibration(self.sa, self.sp)
@@ -211,7 +211,7 @@ class NewScanTest(unittest.TestCase):
         self.assertFalse('sc_iscalibration' in self.sp.md)
 
     def test_dryrun(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         md_copy = dict(self.sc.md)
@@ -220,7 +220,7 @@ class NewScanTest(unittest.TestCase):
         self.assertTrue(md_copy == self.sc.md)
     
     def test_background(self):
-        self.sp = ScanPlan('unittest_count','ct', {'exposure': 0.1}, shutter = False)
+        self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)
         self.sc = Scan(self.sa, self.sp)
         self.assertEqual(self.sc.sp, self.sp)
         background(self.sa, self.sp)

--- a/tests/test_validate_dark.py
+++ b/tests/test_validate_dark.py
@@ -87,7 +87,7 @@ class findRightDarkTest(unittest.TestCase):
             yaml.dump(dark_scan_list, f)
         test_list = _read_dark_yaml()
         self.assertEqual(test_list,dark_scan_list)
-        scanplan = ScanPlan('ctTest', 'ct', {'exposure':light_cnt_time}, shutter=False)
+        scanplan = ScanPlan('ct', {'exposure':light_cnt_time}, shutter=False)
         prun(self.sa, scanplan)
         self.assertTrue('sc_dk_field_uid' in glbl.xpdRE.call_args_list[-1][1])
         self.assertTrue(glbl.xpdRE.call_args_list[-1][1]['sc_dk_field_uid'] == dark_uid)
@@ -107,17 +107,17 @@ class findRightDarkTest(unittest.TestCase):
         test_list = _read_dark_yaml()
         self.assertEqual(test_list,dark_scan_list)
         # none with the right exposure
-        scanplan = ScanPlan('ctTest', 'ct', {'exposure':0.01}, shutter=False)
+        scanplan = ScanPlan('ct', {'exposure':0.01}, shutter=False)
         prun(self.sa, scanplan)
         self.assertTrue('sc_dk_field_uid' in glbl.xpdRE.call_args_list[-1][1])
         self.assertFalse(glbl.xpdRE.call_args_list[-1][1]['sc_dk_field_uid'] == dark_uid2)
         # Second one has the right exposure time but expires
         glbl.dk_window = 1.
-        scanplan = ScanPlan('ctTest', 'ct', {'exposure':0.1}, shutter=False)
+        scanplan = ScanPlan('ct', {'exposure':0.1}, shutter=False)
         prun(self.sa, scanplan)
         self.assertTrue('sc_dk_field_uid' in glbl.xpdRE.call_args_list[-1][1])
         self.assertFalse(glbl.xpdRE.call_args_list[-1][1]['sc_dk_field_uid'] == dark_uid2)
-        
+
     def test_read_dark_yaml(self):
         # test if _read_dark_yaml captures exception as we hope
         self.assertTrue(os.path.isfile(glbl.dk_yaml)) # make sure it exit after _start_beamtime()

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -390,7 +390,7 @@ class ScanPlan(XPD):
         else:
             sp_name = _sp_name
         if auto_dark_plan:
-            sp_name = '_'.join(['auto_dark',sp_name])
+            sp_name = 'auto_dark'
             # when auto_dark collection is called. Avoid overwritting ct
         self.name = sp_name
         self.md.update({'sp_name': _clean_md_input(self.name)})

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -430,7 +430,7 @@ class ScanPlan(XPD):
         for i in range(len(_std_param_list)):
             param = sp_params.get(_std_param_list[i])
             if param: # has element
-                sp_naming_list.append(str(param))
+                sp_naming_list.append('{:.2g}'.format(param))
         return '_'.join(sp_naming_list)
 
     def _scanplan_name_parser(self, sp_name):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -291,7 +291,7 @@ class ScanPlan(XPD):
         An important postional argument that serves two purpose:
 
         *. If you wish to use auto-naming functionality.
-          Please supply this field with a string following allowed scheme, xpdAcq will parse your argument.
+          Please supply this field with a string following allowed scheme, xpdAcq will parse your arguments.
           Currently allowed scheme is like following:
 
           1. 'ct_10' means Count scan with 10s exposure time in total
@@ -304,7 +304,7 @@ class ScanPlan(XPD):
             If you don't want any delay, give it an 0.
 
         *. If you wish to specify parameters explicitly.
-          This field will be "ScanPlan type". Currently allowed values are:
+          This field will be "ScanPlan type". Currently allowed types are:
 
           1. 'ct': which means a count scanplan with exposure time given
 
@@ -328,6 +328,7 @@ class ScanPlan(XPD):
     auto_dark_plan : bool
         argument reserved for auto_dark collection functionality.
         Ususally user doesn't have to specify
+
     Examples
     --------
     Here are examples of instantiating ScanPlan objects with explicit form.
@@ -336,7 +337,7 @@ class ScanPlan(XPD):
     >>> ScanPlan('tseries', {'exposure': 2.5, 'delay': 60,'num':5})
     >>> ScanPlan('Tramp', {'exposure': 2.5, 'sartingT': 300, 'endinT':200, 'Tstep':5})
 
-    Here are examples of instantiating ScanPlan objects with auto namin scheme.
+    Here are examples of instantiating ScanPlan objects with auto naming scheme.
 
     >>> ScanPlan('ct_2.5')
     >>> ScanPlan('tseries_2.5_60_5')

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -514,7 +514,7 @@ class ScanPlan(XPD):
             missed_keys = [ el for el in _ct_required_params if el not in self.sp_params]
             if missed_keys:
                 sys.exit(_graceful_exit('''You are using a "{}" ScanPlan but you missed required parameters:
-                {}'''.format(sefl.scanplan, missed_keys)))
+                {}'''.format(self.scanplan, missed_keys)))
             # check value types
             wrong_type_dict = {}
             for k,v in self.sp_params.items():
@@ -530,7 +530,7 @@ class ScanPlan(XPD):
             missed_keys = [ el for el in _Tramp_required_params if el not in self.sp_params]
             if missed_keys:
                 sys.exit(_graceful_exit('''You are using a "{}" ScanPlan but you missed required parameters:
-                {}'''.format(sefl.scanplan, missed_keys)))
+                {}'''.format(self.scanplan, missed_keys)))
             # check value types
             wrong_type_dict = {}
             for k,v in self.sp_params.items():
@@ -546,7 +546,7 @@ class ScanPlan(XPD):
             missed_keys = [ el for el in _tseries_required_params if el not in self.sp_params]
             if missed_keys:
                 sys.exit(_graceful_exit('''You are using a "{}" ScanPlan but you missed required parameters:
-                {}'''.format(sefl.scanplan, missed_keys)))
+                {}'''.format(self.scanplan, missed_keys)))
             # check value types
             wrong_type_dict = {}
             for k,v in self.sp_params.items():

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -341,7 +341,7 @@ class ScanPlan(XPD):
 
     ScanPlan objects from two sets of examples are equivalent.
     '''
-    def __init__(self, scanplan_meta = '', scanplan_params = {},
+    def __init__(self, scanplan_meta, scanplan_params = {},
             dk_window = None, shutter=True, **kwargs):
         _sp_input = scanplan_meta.strip()
         _std_param_list = self._std_param_list_gen()
@@ -354,7 +354,7 @@ class ScanPlan(XPD):
         elif scanplan_params:
             _sp_name = self._scanplan_auto_name(_sp_input, scanplan_params, _std_param_list)
             self.scanplan = _clean_md_input(_sp_input)
-        # unsupported situation
+        # unsupported situation (won't happen in this version, for future use)
         else:
             print('ScanPlan only takes auto-naming or explicit naming scheme. Please do " ScanPlan? " for more information')
             return

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -325,6 +325,9 @@ class ScanPlan(XPD):
         default is True. If True, in-hutch fast shutter will be opened before a scan and closed afterwards.
         Otherwise control of the shutter is left external. Set to False if you want to control the shutter by hand.
 
+    auto_dark_plan : bool
+        argument reserved for auto_dark collection functionality.
+        Ususally user doesn't have to specify
     Examples
     --------
     Here are examples of instantiating ScanPlan objects with explicit form.
@@ -342,7 +345,7 @@ class ScanPlan(XPD):
     ScanPlan objects from two sets of examples are equivalent.
     '''
     def __init__(self, scanplan_meta, scanplan_params = {},
-            dk_window = None, shutter=True, **kwargs):
+            dk_window = None, shutter=True, *, auto_dark_plan = False, **kwargs):
         _sp_input = scanplan_meta.strip()
         _std_param_list = self._std_param_list_gen()
         # auto naming, parsed parameters
@@ -385,6 +388,9 @@ class ScanPlan(XPD):
             sp_name = '_'.join([_sp_name, _control_params])
         else:
             sp_name = _sp_name
+        if auto_dark_plan:
+            sp_name = '_'.join(['auto_dark',sp_name])
+            # when auto_dark collection is called. Avoid overwritting ct
         self.name = sp_name
         self.md.update({'sp_name': _clean_md_input(self.name)})
         # summary of scanplan created
@@ -430,7 +436,7 @@ class ScanPlan(XPD):
         for i in range(len(_std_param_list)):
             param = sp_params.get(_std_param_list[i])
             if param: # has element
-                sp_naming_list.append('{:.2g}'.format(param))
+                sp_naming_list.append('{:.8g}'.format(param))
         return '_'.join(sp_naming_list)
 
     def _scanplan_name_parser(self, sp_name):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -374,6 +374,7 @@ class ScanPlan(XPD):
         self.md.update({'sp_type': _clean_md_input(self.scanplan)})
         self.md.update({'sp_usermd':_clean_md_input(kwargs)})
         # setting up optional attributes
+        _control_params = ''
         if self.shutter:
             self.md.update({'sp_shutter_control':'in-scan'})
         else:
@@ -383,7 +384,6 @@ class ScanPlan(XPD):
             dk_window = glbl.dk_window
         self.md.update({'sp_dk_window': dk_window})
         # scanplan name should include options, generate it at the last moment
-        _control_params = ''
         if _control_params:
             sp_name = '_'.join([_sp_name, _control_params])
         else:

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -222,12 +222,12 @@ def _execute_start_beamtime(piname,safn,explist,wavelength=None,home_dir=None):
     # now populate the database with some lazy-user objects
     ex = Experiment('l-user',bt)
     sa = Sample('l-user',ex)
-    sc01 = ScanPlan('ct.1s','ct',{'exposure':0.1})
-    sc05 = ScanPlan('ct.5s','ct',{'exposure':0.5})
-    sc1 = ScanPlan('ct1s','ct',{'exposure':1.0})
-    sc5 = ScanPlan('ct5s','ct',{'exposure':5.0})
-    sc10 = ScanPlan('ct10s','ct',{'exposure':10.0})
-    sc30 = ScanPlan('ct30s','ct',{'exposure':30.0})
+    sc01 = ScanPlan('ct',{'exposure':0.1})
+    sc05 = ScanPlan('ct',{'exposure':0.5})
+    sc1 = ScanPlan('ct',{'exposure':1.0})
+    sc5 = ScanPlan('ct',{'exposure':5.0})
+    sc10 = ScanPlan('ct',{'exposure':10.0})
+    sc30 = ScanPlan('ct',{'exposure':30.0})
     return bt
 
 #FIXME this function should be revisited later

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -187,11 +187,11 @@ def _auto_dark_collection(scan, subs={}):
 See documentation at http://xpdacq.github.io for more information about controlling this behavior''')
         # create a count plan with the same light_cnt_time
         if scan.sp.shutter:
-            auto_dark_scanplan = ScanPlan('auto_dark_scan',
-                'ct',{'exposure':light_cnt_time})
+            auto_dark_scanplan = ScanPlan('ct',{'exposure':light_cnt_time},
+                                        auto_dark_plan = True)
         else:
-            auto_dark_scanplan = ScanPlan('auto_dark_scan',
-                'ct',{'exposure':light_cnt_time}, shutter=False)
+            auto_dark_scanplan = ScanPlan('ct',{'exposure':light_cnt_time},
+                                        shutter=False, auto_dark_plan = True)
         dark_field_uid = dark(scan.sa, auto_dark_scanplan, subs)
     auto_dark_md_dict = {'sc_dk_field_uid': dark_field_uid}
     return auto_dark_md_dict


### PR DESCRIPTION
This PR includes refactoring on  ``ScanPlan`` class, suggested in email.  Now the ``ScanPlan`` API is as following:
````
In [1]: ?ScanPlan
Init signature: 
ScanPlan(self, scanplan_meta, scanplan_params={}, dk_window=None, shutter=True, *, auto_dark_plan=False, **kwargs)
````
If user uses auto_naming, this field will be parsed into scan parameters and if user uses long-form, this field is scan_type, and scanplan name will be automatically generated to be consistent with the auto-naming scheme. I am not sure if ``scanplan_meta`` is a good name but I haven't been able to come up with a better name yet.

This PR turns out to be involved with many refactoring. Doc string to ``ScanPlan`` and ``plan_validator`` were rewritten as a more concise format and many ``unittest`` were also refactored since we already changed the way of instantiation.

Code passed simulation and ``unittest`` as well.