### PR TITLE
Work post release fix

### DIFF
--- a/tests/test_scans.py
+++ b/tests/test_scans.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 import os
+import ctypes
 from configparser import ConfigParser
 import shutil
 import time
@@ -153,6 +154,10 @@ class NewScanTest(unittest.TestCase):
         cfg_src = os.path.join(os.path.dirname(__file__), cfg_f_name) # __file__ gives relative path
         cfg_dst = os.path.join(glbl.config_base, cfg_f_name)
         shutil.copy(cfg_src, cfg_dst)
+        # sp_params should be id to object
+        self.assertEqual(id(cc), self.sp.md['sp_params']['bluesky_plan'])
+
+        # case 1: bluesky plan object exist in current name space
         prun(self.sa, self.sp)
         # is xpdRE used?
         self.assertTrue(glbl.xpdRE.called)
@@ -169,6 +174,10 @@ class NewScanTest(unittest.TestCase):
                 glbl.xpdRE.call_args_list[-1][1]['sp_params'])
         # is  ScanPlan.md remain unchanged after scan?
         self.assertFalse('sc_isprun' in self.sp.md)
+
+        # case 2: bluesky plan object doesn't exist in current name spaece
+        del cc
+        self.assertRaises(NameError, lambda: prun(self.sa, self,sp))
 
     def test_dark(self):
         self.sp = ScanPlan('ct', {'exposure': 0.1}, shutter = False)

--- a/xpdacq/analysis.py
+++ b/xpdacq/analysis.py
@@ -164,7 +164,7 @@ def save_tiff(headers, dark_subtraction=True, *, max_count=None):
                 warnings.warn("Requested to do dark correction, but "
                               "extracting the dark image failed.  Proceeding "
                               "without correction.")
-        for ev in get_events(header):
+        for ev in get_events(header, fill=True):
             img = ev['data'][img_field]
             ind = ev['seq_num']
             f_name = _feature_gen(header)

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -321,6 +321,10 @@ class ScanPlan(XPD):
           of plan doesn't work with auto-naming, you must specify
           explicitly.
 
+          Note:
+          'bluesky' plan won't be saved as reusalbe form. Everytime you define a bluesky plan,
+          we **SUGGEST** you to save code that defines your plan in a separate place (for example, a text file)
+
     scan_params : dict
         Optional. Needed if you wish to set up ScanPlan explicitly.
         It contains all scan parameters that will be passed and used at run-time
@@ -350,6 +354,13 @@ class ScanPlan(XPD):
     >>> ScanPlan('Tramp_2.5_300_200_5')
 
     ScanPlan objects from two sets of examples are equivalent.
+
+    Here is an example on how to instantiate ScanPlan carrying a bluesky plan
+    that reads area detector and em channel while moving two-theta motor from -1 to 1 in 20 steps.
+
+    >>> from bluesky.plans import AbsScanPlan
+    >>> myscan = AbsScanPlan([pe1c, em], tth_cal, -1, 1, 20)
+    >>> ScanPlan('bluesky', {'bluesky_plan': myscan})
     '''
     def __init__(self, scanplan_meta, scanplan_params = {},
             dk_window = None, shutter=True, *, auto_dark_plan = False, **kwargs):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -372,12 +372,14 @@ class ScanPlan(XPD):
         self.type = 'sp'
         self.sp_params = scanplan_params # sp_parms is a dictionary
         self._is_bs = False # priviate attribute
-        if 'bluesky_plan' in self.sp_params:
-            self._is_bs = True
         self._plan_validator()
         self.shutter = shutter
         self.md = {}
         self.md.update({'sp_params': scanplan_params})
+        if 'bluesky_plan' in self.sp_params:
+            self._is_bs = True
+            # overwrite as can't yamify ophyd objects now
+            self.md.update({'sp_params': id(scanplan_params)})
         self.md.update({'sp_type': _clean_md_input(self.scanplan)})
         self.md.update({'sp_usermd':_clean_md_input(kwargs)})
         # setting up optional attributes
@@ -420,6 +422,7 @@ class ScanPlan(XPD):
             self.md.update({'sp_uid': olduid})
         else:
             self.md.update({'sp_uid': self._getuid()})
+
         self._yamify()
 
     def _std_param_list_gen(self):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -315,6 +315,12 @@ class ScanPlan(XPD):
           exposure time, starting temperature, ending temperature and
           temperature step specified.
 
+          4. 'bluesky' : which means an arbitrary bluesky plan defined by user
+          For more information please go to : https://nsls-ii.github.io/bluesky/plans.html
+          for complete guide on how to define a plan. Note: bluesky type
+          of plan doesn't work with auto-naming, you must specify
+          explicitly.
+
     scan_params : dict
         Optional. Needed if you wish to set up ScanPlan explicitly.
         It contains all scan parameters that will be passed and used at run-time

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -379,7 +379,9 @@ class ScanPlan(XPD):
         if 'bluesky_plan' in self.sp_params:
             self._is_bs = True
             # overwrite as can't yamify ophyd objects now
-            self.md.update({'sp_params': id(scanplan_params)})
+            plan_obj = scanplan_params['bluesky_plan']
+            plan_id = id(plan_obj)
+            self.md.update({'sp_params': {'bluesky_plan':plan_id}})
         self.md.update({'sp_type': _clean_md_input(self.scanplan)})
         self.md.update({'sp_usermd':_clean_md_input(kwargs)})
         # setting up optional attributes
@@ -409,9 +411,10 @@ class ScanPlan(XPD):
             el = _std_param_list[i]
             try:
                 print('{} = {}'.format(el, self.md['sp_params'][el]))
-            except KeyError:
+            except (KeyError, TypeError):
                 # all errors should be handled before this step
                 # except for bluesky plan
+                # TypeError is for bluesky plan object id
                 pass
         print('with fast-shutter control = {}'.format(self.shutter))
         # yamify ScanPlan

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -100,18 +100,18 @@ class glbl():
         from databroker import get_images as getImages
         from databroker import get_events as getEvents
         from bluesky.callbacks import LiveTable as livetable
-        from bluesky.broker_callbacks import verify_files_saved as verifyFiles
-        
+        from bluesky.callbacks.broker import verify_files_saved as verifyFiles
         from ophyd import EpicsSignalRO, EpicsSignal
-        from bluesky.suspenders import PVSuspendFloor
+        from bluesky.suspenders import SuspendFloor
         ring_current = EpicsSignalRO('SR:OPS-BI{DCCT:1}I:Real-I', name='ring_current')
         xpdRE = RunEngine()
         xpdRE.md['owner'] = owner
         xpdRE.md['beamline_id'] = beamline_id
         xpdRE.md['group'] = group
         register_mds(xpdRE)
-        PVSuspendFloor(xpdRE,'SR:OPS-BI{DCCT:1}I:Real-I',
-                    ring_current.get()-10, resume_thresh = ring_current.get())
+        beamdump_sus = SuspendFloor(ring_current, ring_current.get()*0.9,
+                resume_thresh = ring_current.get()*0.9, sleep = 1200)
+        #xpdRE.install_suspender(beamdump_sus) # don't enable it untill beam is back
         # real imports
         Msg = msg
         Count = count

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -23,6 +23,7 @@ import copy
 import sys
 import uuid
 import warnings
+import ctypes
 from configparser import ConfigParser
 from xpdacq.utils import _graceful_exit, _RE_state_wrapper
 from xpdacq.glbl import glbl
@@ -124,7 +125,9 @@ def _unpack_and_run(scan, dryrun, subs, **kwargs):
     elif scan.md['sp_type'] == 'Tramp':
         collect_Temp_series(scan, parms['startingT'], parms['endingT'], parms['Tstep'], parms['exposure'], area_det, subs, dryrun)
     elif scan.md['sp_type'] == 'bluesky':
-        plan =  parms['bluesky_plan']
+        #plan =  parms['bluesky_plan']
+        plan_id = parms['bluesky_plan']
+        plan = ctypes.cast(plan_id, ctypes.py_object).value
         md_dict = dict(scan.md)
         xpdRE(plan, **md_dict)
     else:

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -137,10 +137,8 @@ def _unpack_and_run(scan, dryrun, subs, **kwargs):
     elif scan.md['sp_type'] == 'Tramp':
         collect_Temp_series(scan, parms['startingT'], parms['endingT'], parms['Tstep'], parms['exposure'], area_det, subs, dryrun)
     elif scan.md['sp_type'] == 'bluesky':
-        #plan =  parms['bluesky_plan']
         plan_id = parms['bluesky_plan']
         plan = _get_bs_plan_by_id(plan_id)
-        #plan = ctypes.cast(plan_id, ctypes.py_object).value
         md_dict = dict(scan.md)
         xpdRE(plan, **md_dict)
     else:

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -15,6 +15,7 @@
 #
 ##############################################################################
 import os
+import gc
 import yaml
 import time
 import datetime
@@ -58,6 +59,17 @@ def _yamify_dark(dark_def):
     dark_list.append(dark_def)
     with open(dark_yaml_name, 'w') as f:
         yaml.dump(dark_list, f)
+
+def _get_bs_plan_by_id(obj_id):
+    for obj in gc.get_objects():
+        if id(obj) == obj_id:
+            return obj
+    raise NameError('''INFO: This bluesky plan object bounded to this ScanPlan doesn't exit anymore.
+    It was probably created/instantiated in previous ipyhton session.
+    Scan will stop here.....
+
+    Please redefine your bluesky scanplan with guide on https://nsls-ii.github.io/bluesky/plans.html
+    You can then pass it to ScanPlan('bluesky',{'bluesky_plan':<your plan>}) and rerun this scan.''')
 
 def _validate_dark(light_cnt_time, expire_time, dark_scan_list = None):
     ''' find appropriate dark frame uid stored in dark_scan_list
@@ -127,7 +139,8 @@ def _unpack_and_run(scan, dryrun, subs, **kwargs):
     elif scan.md['sp_type'] == 'bluesky':
         #plan =  parms['bluesky_plan']
         plan_id = parms['bluesky_plan']
-        plan = ctypes.cast(plan_id, ctypes.py_object).value
+        plan = _get_bs_plan_by_id(plan_id)
+        #plan = ctypes.cast(plan_id, ctypes.py_object).value
         md_dict = dict(scan.md)
         xpdRE(plan, **md_dict)
     else:


### PR DESCRIPTION
This is a fix after xpdAcq v0.3 release on May 26th at XPD.

This PR includes
1) updated syntax based on new software package structure
2) fixes to issue #196 

Current bluesky plan passthrough logic is we yamify reference to the bluesky plan object so that it is still under the framework of ``bt.get(), prun()``...e.t.c.  When program can't find the object based on reference given, it throws an exception and tells use to redefine bluesky plan and instantiate ScanPlan again.

Code now passes simulation and ``unittest``. Detailed docstring to bluesky plan is added as well.   