### PR TITLE
ENH: inject calibration uid

### DIFF
--- a/xpdacq/calib.py
+++ b/xpdacq/calib.py
@@ -101,10 +101,11 @@ def run_calibration(exposure=60, calibrant_file=None, wavelength=None,
         detector = Perkin()
     # scan
     # simplified version of Sample object
+    calib_collection_uid = str(uuid.uuid4())
     calibration_dict = {'sample_name':calibrant_name,
                         'sample_composition':{calibrant_name :1},
-                        'is_calibration': True}
-                         # simplified version of Sample object
+                        'is_calibration': True
+                        'calibration_collection_uid': calib_collection_uid}
     prun_uid = prun(calibration_dict, ScanPlan(bto, ct, exposure))
     light_header = glbl.db[prun_uid[-1]]  # last one is always light
     dark_uid = light_header.start['sc_dk_field_uid']
@@ -153,7 +154,7 @@ def run_calibration(exposure=60, calibrant_file=None, wavelength=None,
     # FIXME: need a solution for selecting desired calibration image
     # based on calibration_collection_uid later
     glbl.calib_config_dict.update({'calibration_collection_uid':
-                                   str(uuid.uuid4())})
+                                   calib_collection_uid)})
     # write yaml
     yaml_name = glbl.calib_config_name
     with open(os.path.join(glbl.config_base, yaml_name), 'w') as f:

--- a/xpdacq/calib.py
+++ b/xpdacq/calib.py
@@ -1,5 +1,6 @@
 """ Script to perform pyFAI calibration in pure Python """
 import os
+import uuid
 import time
 import yaml
 import logging
@@ -149,7 +150,10 @@ def run_calibration(exposure=60, calibrant_file=None, wavelength=None,
     glbl.calib_config_dict.update(Fit2D_dict)
     glbl.calib_config_dict.update({'file_name':basename})
     glbl.calib_config_dict.update({'time':timestr})
-    glbl.calib_config_dict.update({'calibration_uid':prun_uid[-1]})
+    # FIXME: need a solution for selecting desired calibration image
+    # based on calibration_collection_uid later
+    glbl.calib_config_dict.update({'calibration_collection_uid':
+                                   str(uuid.uuid4())})
     # write yaml
     yaml_name = glbl.calib_config_name
     with open(os.path.join(glbl.config_base, yaml_name), 'w') as f:

--- a/xpdacq/calib.py
+++ b/xpdacq/calib.py
@@ -37,7 +37,7 @@ def _check_obj(required_obj_list):
     ips = get_ipython()
     for obj_str in required_obj_list:
         if not ips.ns_table['user_global'].get(obj_str, None):
-            raise NameError("Required object {} doesn't exit in"
+            raise NameError("Required object {} doesn't exist in"
                             "namespace".format(obj_str))
     return
 
@@ -99,9 +99,11 @@ def run_calibration(exposure=60, calibrant_file=None, wavelength=None,
     if detector is None:
         detector = Perkin()
     # scan
-    calibration_dict = {'sample_name': calibrant_name,
-                        'sample_composition': {calibrant_name: 1}}
     # simplified version of Sample object
+    calibration_dict = {'sample_name':calibrant_name,
+                        'sample_composition':{calibrant_name :1},
+                        'is_calibration': True}
+                         # simplified version of Sample object
     prun_uid = prun(calibration_dict, ScanPlan(bto, ct, exposure))
     light_header = glbl.db[prun_uid[-1]]  # last one is always light
     dark_uid = light_header.start['sc_dk_field_uid']
@@ -141,12 +143,13 @@ def run_calibration(exposure=60, calibrant_file=None, wavelength=None,
     c.gui_peakPicker()
     c.ai.setPyFAI(**c.geoRef.getPyFAI())
     c.ai.wavelength = c.geoRef.wavelength
-    # update untile next time
+    # update until next time
     glbl.calib_config_dict = c.ai.getPyFAI()
     Fit2D_dict = c.ai.getFit2D()
     glbl.calib_config_dict.update(Fit2D_dict)
-    glbl.calib_config_dict.update({'file_name': basename})
-    glbl.calib_config_dict.update({'time': timestr})
+    glbl.calib_config_dict.update({'file_name':basename})
+    glbl.calib_config_dict.update({'time':timestr})
+    glbl.calib_config_dict.update({'calibration_uid':prun_uid[-1]})
     # write yaml
     yaml_name = glbl.calib_config_name
     with open(os.path.join(glbl.config_base, yaml_name), 'w') as f:

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -117,6 +117,7 @@ _EXPORT_TAR_DIR = [CONFIG_BASE, USERSCRIPT_DIR]
 class Glbl:
     _is_simulation = simulation
     beamline_host_name = BEAMLINE_HOST_NAME
+    # directory names
     base = BASE_DIR
     home = HOME_DIR
     _export_tar_dir = _EXPORT_TAR_DIR
@@ -133,16 +134,19 @@ class Glbl:
     scanplan_dir = SCANPLAN_DIR
     allfolders = ALL_FOLDERS
     archive_dir = USER_BACKUP_DIR
-    dk_window = DARK_WINDOW
-    # frame_acq_time = FRAME_ACQUIRE_TIME
+    # on/off and attributes for functionality
     auto_dark = True
+    dk_window = DARK_WINDOW
+    _dark_dict_list = [] # initiate a new one every time
     shutter_control = True
+    auto_load_calib = True
+    calib_config_name = CALIB_CONFIG_NAME
+    # beamline name
     owner = OWNER
     beamline_id = BEAMLINE_ID
     group = GROUP
-    _dark_dict_list = []  # initiate a new one every time
+    # instrument config
     det_image_field = IMAGE_FIELD
-    calib_config_name = CALIB_CONFIG_NAME
 
     # logic to assign correct objects depends on simulation or real experiment
     if not simulation:

--- a/xpdacq/tests/pyFAI_calib.yml
+++ b/xpdacq/tests/pyFAI_calib.yml
@@ -1,4 +1,4 @@
-calibration_uid: uuid1234
+calibration_collection_uid: uuid1234
 centerX: !!python/object/apply:numpy.core.multiarray.scalar
 - !!python/object/apply:numpy.dtype
   args: [f8, 0, 1]

--- a/xpdacq/tests/pyFAI_calib.yml
+++ b/xpdacq/tests/pyFAI_calib.yml
@@ -1,4 +1,46 @@
-{detector: Perkin detector, dist: 0.208359323484, file_name: pyFAI_calib_Ni_20160813-1659.poni,
-  pixel1: 0.0002, pixel2: 0.0002, poni1: 0.204863292224, poni2: 0.203364094157, rot1: -0.00294510691846,
-  rot2: 0.00215699775598, rot3: -8.04331174483e-08, splineFile: null, time: 1471126516.892955,
-  wavelength: 1.8333e-11}
+calibration_uid: uuid1234
+centerX: !!python/object/apply:numpy.core.multiarray.scalar
+- !!python/object/apply:numpy.dtype
+  args: [f8, 0, 1]
+  state: !!python/tuple [3, <, null, null, null, -1, -1, 0]
+- !!binary |
+  fONZBRzfj0A=
+centerY: !!python/object/apply:numpy.core.multiarray.scalar
+- !!python/object/apply:numpy.dtype
+  args: [f8, 0, 1]
+  state: !!python/tuple [3, <, null, null, null, -1, -1, 0]
+- !!binary |
+  ru+EJ0EKkEA=
+detector: Perkin detector
+directDist: !!python/object/apply:numpy.core.multiarray.scalar
+- !!python/object/apply:numpy.dtype
+  args: [f8, 0, 1]
+  state: !!python/tuple [3, <, null, null, null, -1, -1, 0]
+- !!binary |
+  b0yD84oLakA=
+dist: 0.208359323484
+file_name: pyFAI_calib_Ni_20160813-1659.poni
+pixel1: 0.0002
+pixel2: 0.0002
+pixelX: 200.0
+pixelY: 200.0
+poni1: 0.204863292224
+poni2: 0.203364094157
+rot1: -0.00294510691846
+rot2: 0.00215699775598
+rot3: -8.04331174483e-08
+splineFile: null
+tilt: !!python/object/apply:numpy.core.multiarray.scalar
+- !!python/object/apply:numpy.dtype
+  args: [f8, 0, 1]
+  state: !!python/tuple [3, <, null, null, null, -1, -1, 0]
+- !!binary |
+  4pMpGLvFyj8=
+tiltPlanRotation: !!python/object/apply:numpy.core.multiarray.scalar
+- !!python/object/apply:numpy.dtype
+  args: [f8, 0, 1]
+  state: !!python/tuple [3, <, null, null, null, -1, -1, 0]
+- !!binary |
+  X3LmBg0cQkA=
+time: 20160813-1815
+wavelength: 1.8333e-11

--- a/xpdacq/tests/test_prun.py
+++ b/xpdacq/tests/test_prun.py
@@ -155,14 +155,16 @@ class PrunTest(unittest.TestCase):
                          0.0002)
         self.assertEqual(auto_calibration_md_dict['file_name'],
                          'pyFAI_calib_Ni_20160813-1659.poni')
+        self.aseertEqual('time', '20160813-1815')
         # file-based config_dict is different from glbl.calib_config_dict
         self.assertTrue(os.path.isfile(cfg_dst))
         glbl.calib_config_dict = dict(auto_calibration_md_dict)
-        glbl.calib_config_dict['new_filed'] = 'i am new'
-        re_auto_calibration_md_dict = _auto_load_calibration_file()
         # trust file-based config_dict
-        self.assertEqual(re_auto_calibration_md_dict, config_from_file)
-        self.assertFalse('new_field' in re_auto_calibration_md_dict)
+        glbl.calib_config_dict['new_filed']='i am new'
+        reload_auto_calibration_md_dict = _auto_load_calibration_file()
+        # trust file-based solution
+        self.assertEqual(reload_auto_calibration_md_dict, config_from_file)
+        self.assertFalse('new_field' in reload_auto_calibration_md_dict)
         # test with prun : auto_load_calib = False -> nothing happpen
         msg_list = []
 
@@ -186,7 +188,9 @@ class PrunTest(unittest.TestCase):
                     if el.command == 'open_run'][0]
         self.assertTrue('sc_calibration_md' in open_run)
         self.assertEqual(open_run['sc_calibration_md'],
-                         re_auto_calibration_md_dict)
+                         reload_auto_calibration_md_dict)
+        self.assertEqual(open_run['calibration_uid'],
+                         reload_auto_calibration_md.get('calibration_uid'))
 
     def test_open_collection(self):
         # no collection

--- a/xpdacq/tests/test_prun.py
+++ b/xpdacq/tests/test_prun.py
@@ -185,13 +185,14 @@ class PrunTest(unittest.TestCase):
         open_run = [el.kwargs for el in msg_list
                     if el.command == 'open_run'][0]
         # modify in place
-        reload_auto_calibration_md_dict.pop('calibration_uid')
+        reload_auto_calibration_md_dict.pop('calibration_collection_uid')
         # test assertion
         self.assertTrue('calibration_md' in open_run)
         self.assertEqual(open_run['calibration_md'],
                          reload_auto_calibration_md_dict)
         # specific info encoded in test file
-        self.assertEqual(open_run['calibration_uid'], 'uuid1234')
+        self.assertEqual(open_run['calibration_collection_uid'],
+                         'uuid1234')
 
     def test_open_collection(self):
         # no collection

--- a/xpdacq/tests/test_prun.py
+++ b/xpdacq/tests/test_prun.py
@@ -155,7 +155,8 @@ class PrunTest(unittest.TestCase):
                          0.0002)
         self.assertEqual(auto_calibration_md_dict['file_name'],
                          'pyFAI_calib_Ni_20160813-1659.poni')
-        self.aseertEqual('time', '20160813-1815')
+        self.assertEqual(auto_calibration_md_dict['time'],
+                        '20160813-1815')
         # file-based config_dict is different from glbl.calib_config_dict
         self.assertTrue(os.path.isfile(cfg_dst))
         glbl.calib_config_dict = dict(auto_calibration_md_dict)
@@ -190,7 +191,7 @@ class PrunTest(unittest.TestCase):
         self.assertEqual(open_run['sc_calibration_md'],
                          reload_auto_calibration_md_dict)
         self.assertEqual(open_run['calibration_uid'],
-                         reload_auto_calibration_md.get('calibration_uid'))
+                         reload_auto_calibration_md_dict.get('calibration_uid'))
 
     def test_open_collection(self):
         # no collection

--- a/xpdacq/tests/test_prun.py
+++ b/xpdacq/tests/test_prun.py
@@ -177,7 +177,7 @@ class PrunTest(unittest.TestCase):
         prun_uid = self.prun(0,0)
         open_run = [el.kwargs for el in msg_list
                     if el.command=='open_run'][0]
-        self.assertFalse('sc_calibration_md' in open_run)
+        self.assertFalse('calibration_md' in open_run)
         # test with prun : auto_load_calib = True -> full calib_md
         msg_list = []
         def msg_rv(msg):
@@ -187,11 +187,14 @@ class PrunTest(unittest.TestCase):
         prun_uid = self.prun(0,0)
         open_run = [el.kwargs for el in msg_list
                     if el.command == 'open_run'][0]
-        self.assertTrue('sc_calibration_md' in open_run)
-        self.assertEqual(open_run['sc_calibration_md'],
+        # modify in place
+        reload_auto_calibration_md_dict.pop('calibration_uid')
+        # test assertion
+        self.assertTrue('calibration_md' in open_run)
+        self.assertEqual(open_run['calibration_md'],
                          reload_auto_calibration_md_dict)
-        self.assertEqual(open_run['calibration_uid'],
-                         reload_auto_calibration_md_dict.get('calibration_uid'))
+        # specific info encoded in test file
+        self.assertEqual(open_run['calibration_uid'], 'uuid1234')
 
     def test_open_collection(self):
         # no collection

--- a/xpdacq/tests/test_prun.py
+++ b/xpdacq/tests/test_prun.py
@@ -163,14 +163,25 @@ class PrunTest(unittest.TestCase):
         # trust file-based config_dict
         self.assertEqual(re_auto_calibration_md_dict, config_from_file)
         self.assertFalse('new_field' in re_auto_calibration_md_dict)
-        # test with prun
+        # test with prun : auto_load_calib = False -> nothing happpen
         msg_list = []
 
         def msg_rv(msg):
             msg_list.append(msg)
 
         self.prun.msg_hook = msg_rv
-        prun_uid = self.prun(0, 0)
+        glbl.auto_load_calib = False
+        prun_uid = self.prun(0,0)
+        open_run = [el.kwargs for el in msg_list
+                    if el.command=='open_run'][0]
+        self.assertFalse('sc_calibration_md' in open_run)
+        # test with prun : auto_load_calib = True -> full calib_md
+        msg_list = []
+        def msg_rv(msg):
+            msg_list.append(msg)
+        self.prun.msg_hook = msg_rv
+        glbl.auto_load_calib = True
+        prun_uid = self.prun(0,0)
         open_run = [el.kwargs for el in msg_list
                     if el.command == 'open_run'][0]
         self.assertTrue('sc_calibration_md' in open_run)

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -217,9 +217,10 @@ def _inject_calibration_md(msg):
         calibration_md = _auto_load_calibration_file()
         if calibration_md:
             injected_calib_dict = dict(calibration_md)
-            injected_calib_uid = injected_calib_dict.pop('calibration_uid')
+            injected_calib_uid = injected_calib_dict.pop(
+                                 'calibration_collection_uid')
             msg.kwargs['calibration_md'] = injected_calib_dict
-            msg.kwargs['calibration_uid'] = injected_calib_uid
+            msg.kwargs['calibration_collection_uid'] = injected_calib_uid
     return msg
 
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -214,10 +214,11 @@ def _inject_qualified_dark_frame_uid(msg):
 def _inject_calibration_md(msg):
     if msg.command == 'open_run':
         calibration_md = _auto_load_calibration_file()
-        msg.kwargs['sc_calibration_md'] = calibration_md
-        calib_uid = calibration_md['calibration_uid']
-        # flat dict, make search earsier in the future
-        msg.kwargs['calibration_uid'] = calib_uid
+        if calibration_md:
+            msg.kwargs['sc_calibration_md'] = calibration_md
+            calib_uid = calibration_md['calibration_uid']
+            # flat dict, make search earsier in the future
+            msg.kwargs['calibration_uid'] = calib_uid
     return msg
 
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -214,11 +214,12 @@ def _inject_qualified_dark_frame_uid(msg):
 def _inject_calibration_md(msg):
     if msg.command == 'open_run':
         calibration_md = _auto_load_calibration_file()
+        # it user has run a calibration set before
         if calibration_md:
-            msg.kwargs['sc_calibration_md'] = calibration_md
-            calib_uid = calibration_md['calibration_uid']
-            # flat dict, make search earsier in the future
-            msg.kwargs['calibration_uid'] = calib_uid
+            injected_calib_dict = dict(calibration_md)
+            injected_calib_uid = injected_calib_dict.pop('calibration_uid')
+            msg.kwargs['calibration_md'] = injected_calib_dict
+            msg.kwargs['calibration_uid'] = injected_calib_uid
     return msg
 
 


### PR DESCRIPTION
Enhancement on injecting calibration metadata to header. ``calibration_uid`` and ``is_calibration`` filed are now both included in the metadata fields in ``header``. 

Code passes simulation and ``unittest``.

Note: commit history looks long because rebase.