### PR TITLE
ENH: import sample

### DIFF
--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -321,8 +321,9 @@ class Beamtime(ValidatedDictLike, YamlDict):
             self.scanplans.remove(old_obj)
             self.scanplans.insert(old_obj_ind, scanplan)
         # yaml sync list
-        self._referenced_by.extend([el for el in self.scanplans if el
-                                    not in self._referenced_by])
+        #self._referenced_by.extend([el for el in self.scanplans if el
+        #                            not in self._referenced_by])
+        self._referenced_by.append(scanplan)
 
     @property
     def md(self):
@@ -355,8 +356,9 @@ class Beamtime(ValidatedDictLike, YamlDict):
             self.samples.remove(old_obj)
             self.samples.insert(old_obj_ind, sample)
         # yaml sync list
-        self._referenced_by.extend([el for el in self.samples if el
-                                    not in self._referenced_by])
+        #self._referenced_by.extend([el for el in self.samples if el
+        #                            not in self._referenced_by])
+        self._referenced_by.append(sample)
 
     @classmethod
     def from_yaml(cls, f):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -361,6 +361,8 @@ class Beamtime(ValidatedDictLike, YamlDict):
         # filtering logic is handle when importing sample
         #self._referenced_by.extend([el for el in self.samples if el
         #                            not in self._referenced_by])
+        # simply append object to list to increase speed
+        # filtering logic is handle when importing sample
         self._referenced_by.append(sample)
 
     @classmethod

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -324,6 +324,8 @@ class Beamtime(ValidatedDictLike, YamlDict):
             self.scanplans.insert(old_obj_ind, scanplan)
         # yaml sync list
         # simply append object to list to increase speed
+        #self._referenced_by.extend([el for el in self.scanplans if el
+        #                            not in self._referenced_by])
         self._referenced_by.append(scanplan)
 
     @property
@@ -357,6 +359,8 @@ class Beamtime(ValidatedDictLike, YamlDict):
         # yaml sync list
         # simply append object to list to increase speed
         # filtering logic is handle when importing sample
+        #self._referenced_by.extend([el for el in self.samples if el
+        #                            not in self._referenced_by])
         self._referenced_by.append(sample)
 
     @classmethod

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -310,6 +310,8 @@ class Beamtime(ValidatedDictLike, YamlDict):
         self.update(bt_wavelength=val)
 
     def register_scanplan(self, scanplan):
+        # Notify this Beamtime about an ScanPlan that should be re-synced
+        # whenever the contents of the Beamtime are edited. 
         sp_name_list = [el.short_summary() for el in self.scanplans]
         # manage bt.list
         if scanplan.short_summary() not in sp_name_list:
@@ -321,8 +323,7 @@ class Beamtime(ValidatedDictLike, YamlDict):
             self.scanplans.remove(old_obj)
             self.scanplans.insert(old_obj_ind, scanplan)
         # yaml sync list
-        #self._referenced_by.extend([el for el in self.scanplans if el
-        #                            not in self._referenced_by])
+        # simply append object to list to increase speed
         self._referenced_by.append(scanplan)
 
     @property
@@ -346,18 +347,16 @@ class Beamtime(ValidatedDictLike, YamlDict):
         sa_name_list = [el.get('sample_name', None) for el in self.samples]
         # manage bt.list
         if sample.get('sample_name') not in sa_name_list:
-            # print('!!! Got new sample !!!')
             self.samples.append(sample)
         else:
-            # print('!!! Overwrite sample !!!')
             old_obj = [obj for obj in self.samples if obj.get('sample_name') ==
                        sample.get('sample_name')].pop()
             old_obj_ind = self.samples.index(old_obj)
             self.samples.remove(old_obj)
             self.samples.insert(old_obj_ind, sample)
         # yaml sync list
-        #self._referenced_by.extend([el for el in self.samples if el
-        #                            not in self._referenced_by])
+        # simply append object to list to increase speed
+        # filtering logic is handle when importing sample
         self._referenced_by.append(sample)
 
     @classmethod

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -9,8 +9,10 @@ import bluesky.examples as be
 
 # define simulated PE1C
 class SimulatedPE1C(be.Reader):
-    """Subclass the bluesky plain detector examples ('Reader'); add attributes."""
-
+    """
+    Subclass the bluesky plain detector examples ('Reader');
+    add attributes.
+    """
     def __init__(self, name, read_fields):
         self.images_per_set = MagicMock()
         self.images_per_set.get = MagicMock(return_value=5)

--- a/xpdacq/tests/test_import_sample.py
+++ b/xpdacq/tests/test_import_sample.py
@@ -1,0 +1,55 @@
+import os
+import yaml
+import shutil
+import unittest
+from mock import MagicMock
+
+from xpdacq.glbl import glbl
+from xpdacq.beamtimeSetup import (_start_beamtime, _end_beamtime,
+                                  load_beamtime)
+from xpdacq.beamtime import (_summarize, ScanPlan, ct, Tramp, tseries,
+                             Beamtime, Sample)
+from xpdacq.utils import import_sample
+from bluesky.examples import motor, det, Reader
+
+# print messages for debugging
+#prun.msg_hook = print
+
+class BeamtimeObjTest(unittest.TestCase):
+
+    def setUp(self):
+        self.base_dir = glbl.base
+        self.home_dir = os.path.join(self.base_dir,'xpdUser')
+        self.config_dir = os.path.join(self.base_dir,'xpdConfig')
+        self.PI_name = 'Billinge '
+        self.saf_num = 30079   # must be 30079 for proper load of config yaml => don't change
+        self.wavelength = 0.1812
+        self.experimenters = [('van der Banerjee','S0ham',1),
+                              ('Terban ',' Max',2)]
+        # make xpdUser dir. That is required for simulation
+        os.makedirs(self.home_dir, exist_ok=True)
+        self.bt = _start_beamtime(self.PI_name, self.saf_num,
+                                  self.experimenters,
+                                  wavelength=self.wavelength)
+        xlf = '30079_sample.xlsx'
+        src = os.path.join(os.path.dirname(__file__), xlf)
+        shutil.copyfile(src, os.path.join(glbl.xpdconfig, xlf))
+
+    def tearDown(self):
+        os.chdir(self.base_dir)
+        if os.path.isdir(self.home_dir):
+            shutil.rmtree(self.home_dir)
+        if os.path.isdir(os.path.join(self.base_dir,'xpdConfig')):
+            shutil.rmtree(os.path.join(self.base_dir,'xpdConfig'))
+        if os.path.isdir(os.path.join(self.base_dir,'pe2_data')):
+            shutil.rmtree(os.path.join(self.base_dir,'pe2_data'))
+
+
+    def test_import_sample(self):
+        # direct sample -> no ipython session, fail as expect
+        self.assertRaises(AttributeError, lambda: import_sample())
+        # explict import
+        import_sample(30079, self.bt)
+        # incorrect file name
+        self.assertRaises(FileNotFoundError,
+                          lambda: import_sample(12345, self.bt))

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -314,8 +314,8 @@ class ExceltoYaml:
         for el in self.parsed_sa_md_list:
             Sample(bt, el)
         # separate so that bkg is in the back
-        for el in self.parsed_sa_md_list:
-            bkg_name = el['geometry']  # bkg
+        bkg_name_list = [el['geometry'] for el in self.parsed_sa_md_list]
+        for bkg_name in set(bkg_name_list):
             bkg_dict = {'sample_name': 'bkg_' + bkg_name,
                         'sample_composition': {bkg_name: 1},
                         'is_background': True}
@@ -451,6 +451,9 @@ def import_sample(saf_num, bt):
         beamtime object that is going to be linked with these samples
     """
     bt.samples = []
+    ## !! test needs to be carefull !!! ##
+    bt._referenced_by = []
+    ##
     excel_to_yaml.load(str(saf_num))
     excel_to_yaml.create_yaml(bt)
     return excel_to_yaml

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -8,7 +8,7 @@ from shutil import ReadError
 import pandas as pd
 
 from .glbl import glbl
-from .beamtime import Sample
+from .beamtime import Sample, ScanPlan
 
 
 def _graceful_exit(error_message):
@@ -451,8 +451,9 @@ def import_sample(saf_num, bt):
         beamtime object that is going to be linked with these samples
     """
     bt.samples = []
-    ## !! test needs to be carefull !!! ##
-    bt._referenced_by = []
+    ## !! this test needs to be treated carefully !!! ##
+    sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
+    bt._referenced_by = sp_ref
     ##
     excel_to_yaml.load(str(saf_num))
     excel_to_yaml.create_yaml(bt)

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -484,17 +484,10 @@ def import_sample(saf_num=None, bt=None):
                   "object?")
             return
     bt.samples = []
-<<<<<<< HEAD
     # exclude Sample objects from reference list
     # logic: only update Sample objects that are currently in bt.list
     sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
     bt._referenced_by = sp_ref
-=======
-    ## !! this test needs to be treated carefully !!! ##
-    sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
-    bt._referenced_by = sp_ref
-    ##
->>>>>>> fc845bb... ENH: select ScanPlan from  bt._referenced_by list before cleaning
     excel_to_yaml.load(str(saf_num))
     excel_to_yaml.create_yaml(bt)
     return excel_to_yaml

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -9,6 +9,24 @@ import pandas as pd
 
 from .glbl import glbl
 from .beamtime import Sample, ScanPlan
+from IPython import get_ipython
+
+def _check_obj(required_obj_list):
+    """ function to check if object(s) exist
+
+    Parameter
+    ---------
+    required_obj_list : list
+        a list of strings refering to object names
+
+    """
+    ips = get_ipython()
+    for obj_str in required_obj_list:
+        if not ips.ns_table['user_global'].get(obj_str, None):
+            raise NameError("Required object {} doesn't exist in"
+                            "namespace".format(obj_str))
+    return
+
 
 def _check_obj(required_obj_list):
     """ function to check if object(s) exist

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -10,7 +10,6 @@ import pandas as pd
 from .glbl import glbl
 from .beamtime import Sample, ScanPlan
 
-
 def _graceful_exit(error_message):
     try:
         raise RuntimeError(error_message)

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -239,35 +239,43 @@ def _copy_and_delete(f_name, src_full_path, dst_dir):
 
 class ExceltoYaml:
     # maintain in place, aligned with spreadsheet header
-    NAME_FIELD = ['Collaborators', 'Sample Maker', 'Lead Experimenters', ]
+    NAME_FIELD = ['Collaborators', 'Sample Maker', 'Lead Experimenter', ]
     COMMA_SEP_FIELD = ['cif name', 'Tags']
-    SAMPLE_FIELD = ['Phase Info']
+    PHASE_FIELD = ['Phase Info [required]']
+    SAMPLE_NAME_FIELD = ['Sample Name [required]']
     GEOMETRY_FIELD = ['Geometry']
+    DICT_LIKE_FIELD = ['database id'] # return a dict
 
     # real fields goes into metadata store
     _NAME_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
                            NAME_FIELD))
     _COMMA_SEP_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
                                 COMMA_SEP_FIELD))
-    _SAMPLE_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
-                             SAMPLE_FIELD))
+    _SAMPLE_NAME_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
+                                  SAMPLE_NAME_FIELD))
+    _PHASE_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
+                            PHASE_FIELD))
     _GEOMETRY_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
                                GEOMETRY_FIELD))
+    _DICT_LIKE_FIELD = list(map(lambda x: x.lower().replace(' ', '_'),
+                                DICT_LIKE_FIELD))
 
     def __init__(self):
         self.pd_dict = None
         self.sa_md_list = None
+        self.src_dir = glbl.import_dir
 
     def load(self, saf_num):
-        xl_f = [f for f in os.listdir(glbl.xpdconfig) if
-                f.startswith(str(saf_num) + '_sample')]
+        xl_f = [f for f in os.listdir(self.src_dir) if
+                f in (str(saf_num)+'_sample.xls',
+                      str(saf_num)+'_sample.xlsx')]
         if not xl_f:
-            raise FileNotFoundError("assigned file doesn't exist")
-        if len(xl_f) > 1:
-            raise ValueError("Found more than one file, please make sure"
-                             "there is only one in {}"
-                             .format(glbl.xpdconfig))
-        self.pd_dict = pd.read_excel(os.path.join(glbl.xpdconfig,
+            raise FileNotFoundError("assigned file doesn't exist, have "
+                                    "you put it into {} with correct "
+                                    "naming scheme yet?"
+                                    .format(self.src_dir))
+
+        self.pd_dict = pd.read_excel(os.path.join(self.src_dir,
                                                   xl_f.pop()),
                                      skiprows=0)
 
@@ -312,8 +320,8 @@ class ExceltoYaml:
                     parsed_sa_md.setdefault(k, [])
                     parsed_sa_md.get(k).extend(parsed_name)
 
-                # sample fields
-                elif k in self._SAMPLE_FIELD:
+                # phase fields
+                elif k in self._PHASE_FIELD:
                     try:
                         composition_dict, phase_dict = self._phase_parser(v)
                     except ValueError:
@@ -337,6 +345,15 @@ class ExceltoYaml:
                     parsed_sa_md.setdefault(k, [])
                     parsed_sa_md.get(k).extend(comma_sep_list)
 
+                # sample name field
+                elif k in self._SAMPLE_NAME_FIELD:
+                    _k = 'sample_name'
+                    parsed_sa_md.update({_k: v.replace(' ','_')})
+
+                # dict-like field
+                elif k in self._DICT_LIKE_FIELD:
+                    parsed_sa_md.update({k: self._dict_like_parser(v)})
+
                 # other fields dont need to be pased
                 else:
                     parsed_sa_md.update({k: v.replace(' ', '_')})
@@ -348,12 +365,14 @@ class ExceltoYaml:
         for el in self.parsed_sa_md_list:
             Sample(bt, el)
         # separate so that bkg is in the back
-        bkg_name_list = [el['geometry'] for el in self.parsed_sa_md_list]
+        bkg_name_list = [el['sample_name']
+                         for el in self.parsed_sa_md_list if
+                         el['sample_name'].startswith('bkgd')]
         for bkg_name in set(bkg_name_list):
-            bkg_dict = {'sample_name': 'bkg_' + bkg_name,
+            bkg_dict = {'sample_name': bkg_name,
                         'sample_composition': {bkg_name: 1},
                         'is_background': True}
-            Sample(bt, bkg_dict)  # bk sample object, overwrite
+            Sample(bt, bkg_dict)
 
         print("*** End of import Sample object ***")
 
@@ -380,6 +399,20 @@ class ExceltoYaml:
             sa_md_list.append(sa_md)
 
         return sa_md_list
+
+    def _dict_like_parser(self, input_str):
+        """ parser for dictionary output"""
+        output_dict = {}
+        dict_meta = input_str.split(',')
+        for el in dict_meta:
+            if len(el.split(':')) == 1:
+                key = el.split(':').pop()
+                val = 'N/A'  # capture default
+            else:
+                key, val = el.split(':')
+            output_dict.update({key.strip(): val.strip()})
+
+        return output_dict
 
     def _comma_separate_parser(self, input_str):
         """ parser for comma separated fields
@@ -413,6 +446,8 @@ class ExceltoYaml:
             a list of strings in [<first_name>, <last_name>] form
         """
         name_list = name_str.split(' ')
+        if len(name_list) > 2:
+            name_list = [name_str]
         return name_list  # [first, last]
 
     def _phase_parser(self, phase_str):
@@ -452,6 +487,7 @@ class ExceltoYaml:
                 amount = '1'  # capture default
             else:
                 com, amount = el.split(':')  # expect [<com>, <amount>]
+                amount = amount.replace('%','')
             phase_dict.update({com.strip(): float(amount.strip())})
             parsed_tuple = composition_analysis(com.strip())
             # expect: ([elment_1, element_2, ...], [sto_1, sto_2,...])
@@ -501,6 +537,7 @@ def import_sample(saf_num=None, bt=None):
                   "beamtime objec.\n Do you feed in a valid beamtime "
                   "object?")
             return
+    print('INFO: using SAF_number = {}'.format(saf_num))
     bt.samples = []
     # exclude Sample objects from reference list
     # logic: only update Sample objects that are currently in bt.list

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -450,10 +450,10 @@ def import_sample(saf_num, bt):
         beamtime object that is going to be linked with these samples
     """
     bt.samples = []
-    ## !! this test needs to be treated carefully !!! ##
+    # exclude Sample objects from reference list
+    # logic: only update Sample objects that are currently in bt.list
     sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
     bt._referenced_by = sp_ref
-    ##
     excel_to_yaml.load(str(saf_num))
     excel_to_yaml.create_yaml(bt)
     return excel_to_yaml

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -484,10 +484,17 @@ def import_sample(saf_num=None, bt=None):
                   "object?")
             return
     bt.samples = []
+<<<<<<< HEAD
     # exclude Sample objects from reference list
     # logic: only update Sample objects that are currently in bt.list
     sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
     bt._referenced_by = sp_ref
+=======
+    ## !! this test needs to be treated carefully !!! ##
+    sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
+    bt._referenced_by = sp_ref
+    ##
+>>>>>>> fc845bb... ENH: select ScanPlan from  bt._referenced_by list before cleaning
     excel_to_yaml.load(str(saf_num))
     excel_to_yaml.create_yaml(bt)
     return excel_to_yaml

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -10,6 +10,23 @@ import pandas as pd
 from .glbl import glbl
 from .beamtime import Sample, ScanPlan
 
+def _check_obj(required_obj_list):
+    """ function to check if object(s) exist
+
+    Parameter
+    ---------
+    required_obj_list : list
+        a list of strings refering to object names
+
+    """
+    ips = get_ipython()
+    for obj_str in required_obj_list:
+        if not ips.ns_table['user_global'].get(obj_str, None):
+            raise NameError("Required object {} doesn't exist in"
+                            "namespace".format(obj_str))
+    return
+
+
 def _graceful_exit(error_message):
     try:
         raise RuntimeError(error_message)
@@ -449,6 +466,23 @@ def import_sample(saf_num, bt):
     bt : xpdacq.beamtime.Beamtime
         beamtime object that is going to be linked with these samples
     """
+    if bt is None:
+        # NameError will rise in _check_obj
+        _check_obj(['bt'])
+        ips = get_ipython()
+        bt = ips.ns_table['user_global']['bt']
+    if saf_num is None:
+        try:
+            saf_num = bt['bt_safN']
+        except NameError:
+            print("WARNING: there is no beamtime object (bt) exists in "
+                  "current namespace.\n Have you started a beamtime ? ")
+            return
+        except KeyError:
+            print("WARNING: there is no SAF number information in this "
+                  "beamtime objec.\n Do you feed in a valid beamtime "
+                  "object?")
+            return
     bt.samples = []
     # exclude Sample objects from reference list
     # logic: only update Sample objects that are currently in bt.list

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -451,7 +451,7 @@ class ExceltoYaml:
 excel_to_yaml = ExceltoYaml()
 
 
-def import_sample(saf_num, bt):
+def import_sample(saf_num=None, bt=None):
     """ import sample metadata based on a spreadsheet
 
     this function expect a prepopulated '<SAF_number>_sample.xls' file 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -320,10 +320,11 @@ class CustomizedRunEngine(RunEngine):
                                         resume_thresh=glbl.ring_current.get() * 0.9,
                                         sleep=1200)
             glbl.suspender = beamdump_sus
-            #FIXME : print info for user
-            #self.install_suspender(beamdump_sus)
-            #print("INFO: beam dump suspender has been created."
-            #      "To check, type prun.suspenders")
+            # FIXME : print info for user
+            # self.install_suspender(beamdump_sus)
+            # print("INFO: beam dump suspender has been created."
+            #        " to check, please do\n:"
+            #        ">>> prun.suspenders")
         else:
             pass
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -323,6 +323,8 @@ class CustomizedRunEngine(RunEngine):
             # FIXME : print info for user
             # self.install_suspender(beamdump_sus)
             # print("INFO: beam dump suspender has been created."
+            #        " to check, please do\n:"
+            #        ">>> prun.suspenders")
         else:
             pass
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -323,7 +323,6 @@ class CustomizedRunEngine(RunEngine):
             # FIXME : print info for user
             # self.install_suspender(beamdump_sus)
             # print("INFO: beam dump suspender has been created."
-            #      "To check, type prun.suspenders")
         else:
             pass
 

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -320,11 +320,10 @@ class CustomizedRunEngine(RunEngine):
                                         resume_thresh=glbl.ring_current.get() * 0.9,
                                         sleep=1200)
             glbl.suspender = beamdump_sus
-            # FIXME : print info for user
-            # self.install_suspender(beamdump_sus)
-            # print("INFO: beam dump suspender has been created."
-            #        " to check, please do\n:"
-            #        ">>> prun.suspenders")
+            #FIXME : print info for user
+            #self.install_suspender(beamdump_sus)
+            #print("INFO: beam dump suspender has been created."
+            #      "To check, type prun.suspenders")
         else:
             pass
 


### PR DESCRIPTION
Enhance ``import_sample`` functionality. 

This PR mainly focus on increasing speed, now it takes ~700ms for a list of 80 Sample objects.

Current logic of ``bt.list`` is:
1. when calling ``import_sample`` function, ``Sample`` object list is entirely flushed and updated based on current spreadsheet contents. ``ScanPlan`` object list stays the same.

2. when creating objects in command line, like ``Sample(.....)``, objects in ``bt.list`` with the same sample name will be updated(overwritten), while keep index unchanged.

