### PR TITLE
refactor glbl class

### DIFF
--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -1,8 +1,8 @@
 import os
 import socket
 import time
-from unittest.mock import MagicMock
 from time import strftime, sleep
+from xpdacq.yamldict import YamlDict
 
 # better to get this from a config file in the fullness of time
 HOME_DIR_NAME = 'xpdUser'
@@ -29,7 +29,6 @@ else:
 if simulation:
     BASE_DIR = os.getcwd()
 else:
-    #BASE_DIR = os.path.expanduser('~/')
     BASE_DIR = os.path.abspath('/direct/XF28ID1/pe2_data')
 
 # top directories
@@ -49,7 +48,6 @@ config_base/
 """
 BT_DIR = YAML_DIR
 SAMPLE_DIR = os.path.join(YAML_DIR, 'samples')
-EXPERIMENT_DIR = os.path.join(YAML_DIR, 'experiments')
 SCANPLAN_DIR = os.path.join(YAML_DIR, 'scanplans')
 # other dirs
 IMPORT_DIR = os.path.join(HOME_DIR, 'Import')
@@ -64,7 +62,6 @@ ALL_FOLDERS = [
     YAML_DIR,
     CONFIG_BASE,
     SAMPLE_DIR,
-    EXPERIMENT_DIR,
     SCANPLAN_DIR,
     TIFF_BASE,
     USERSCRIPT_DIR,
@@ -77,84 +74,140 @@ _EXCLUDE_DIR = [HOME_DIR, BLCONFIG_DIR, YAML_DIR]
 _EXPORT_TAR_DIR = [CONFIG_BASE, USERSCRIPT_DIR]
 
 
-class Glbl:
-    _is_simulation = simulation
-    beamline_host_name = BEAMLINE_HOST_NAME
-    # directory names
-    base = BASE_DIR
-    home = HOME_DIR
-    _export_tar_dir = _EXPORT_TAR_DIR
-    xpdconfig = BLCONFIG_DIR
-    import_dir = IMPORT_DIR
-    config_base = CONFIG_BASE
-    tiff_base = TIFF_BASE
-    usrScript_dir = USERSCRIPT_DIR
-    usrAnalysis_dir = ANALYSIS_DIR
-    yaml_dir = YAML_DIR
-    bt_dir = BT_DIR
-    sample_dir = SAMPLE_DIR
-    experiment_dir = EXPERIMENT_DIR
-    scanplan_dir = SCANPLAN_DIR
-    allfolders = ALL_FOLDERS
-    archive_dir = USER_BACKUP_DIR
-    # on/off and attributes for functionality
-    auto_dark = True
-    dk_window = DARK_WINDOW
-    _dark_dict_list = [] # initiate a new one every time
-    shutter_control = True
-    auto_load_calib = True
-    calib_config_name = CALIB_CONFIG_NAME
-    # beamline name
-    owner = OWNER
-    beamline_id = BEAMLINE_ID
-    group = GROUP
-    # instrument config
-    det_image_field = IMAGE_FIELD
-    mask_md_name = MASK_MD_NAME
-
-    # logic to assign correct objects depends on simulation or real experiment
-    if not simulation:
-        # FIXME: it seems to be unused, confirm and delete
-        #from bluesky.callbacks.broker import verify_files_saved as verifyFiles
-        from ophyd import EpicsSignalRO, EpicsSignal
-        from bluesky.suspenders import SuspendFloor
-        ring_current = EpicsSignalRO('SR:OPS-BI{DCCT:1}I:Real-I',
-                                     name='ring_current')
-        #verify_files_saved = verifyFiles
-    else:
-        archive_dir = os.path.join(BASE_DIR, 'userSimulationArchive')
-
-    # object should be handled by ipython profile
-    db = None
-    area_det = None
-    temp_controller = None
-    shutter = None
-    verify_files_saved = None
-
-    # default masking dict
-    mask_dict = {'edge': 30, 'lower_thresh': 0.0,
-                 'upper_thresh': None, 'bs_width': 13,
-                 'tri_offset': 13, 'v_asym': 0,
-                 'alpha': 2.5, 'tmsk': None}
-
-    def __init__(self, frame_acq_time=FRAME_ACQUIRE_TIME):
-        self._frame_acq_time = frame_acq_time
-
-    @property
-    def frame_acq_time(self):
-        return self._frame_acq_time
-
-    @frame_acq_time.setter
-    def frame_acq_time(self, val):
-        self.area_det.cam.acquire.put(0)
-        time.sleep(1)
-        self.area_det.number_of_sets.put(1)
-        self.area_det.cam.acquire_time.put(val)
-        time.sleep(1)
-        self.area_det.cam.acquire.put(1)
-        print("INFO: area detector has been configured to new"
-              " exposure_time = {}s".format(val))
-        self._frame_acq_time = val
+glbl_dict = {
+             '_is_simulation': simulation,
+             # beamline info
+             'owner':OWNER,
+             'beamline_id': BEAMLINE_ID,
+             'group': GROUP,
+             'beamline_host_name': BEAMLINE_HOST_NAME,
+             # directory names
+             'base': BASE_DIR,
+             'home': HOME_DIR,
+             '_export_tar_dir': _EXPORT_TAR_DIR,
+             'xpdconfig': BLCONFIG_DIR,
+             'import_dir': IMPORT_DIR,
+             'config_base': CONFIG_BASE,
+             'tiff_base': TIFF_BASE,
+             'usrScript_dir': USERSCRIPT_DIR,
+             'usrAnalysis_dir': ANALYSIS_DIR,
+             'yaml_dir': YAML_DIR,
+             'bt_dir': BT_DIR,
+             'sample_dir': SAMPLE_DIR,
+             'scanplan_dir': SCANPLAN_DIR,
+             'allfolders': ALL_FOLDERS,
+             'archive_dir': USER_BACKUP_DIR,
+             # options for functionalities
+             'auto_dark': True,
+             'dk_window': DARK_WINDOW,
+             '_dark_dict_list': [], # initiate a new one every time
+             'shutter_control': True,
+             'auto_load_calib': True,
+             'calib_config_name': CALIB_CONFIG_NAME,
+             'mask_dict': {'edge': 30, 'lower_thresh': 0.0,
+                           'upper_thresh': None, 'bs_width': 13,
+                           'tri_offset': 13, 'v_asym': 0,
+                           'alpha': 2.5, 'tmsk': None},
+             # instrument config
+             'det_image_field': IMAGE_FIELD,
+             'mask_md_name': MASK_MD_NAME
+             }
 
 
-glbl = Glbl()
+# dict to store all necessary dict
+xpd_device = {}
+
+def setup_xpdAcq(device_list, *, area_det, shutter, temp_controller, db,
+                 **kwargs):
+    """ function to set up required device/objects for xpdacq """
+    REQUIRED_KEYS = ['area_det', 'shutter', 'temp_controller', 'db']
+    for key, device in zip(REQUIRED_KEYS, device_list):
+        try:
+            xpd_device.update(key, device)
+        except NameError:
+            pass
+    xpd_device.update(**kwargs)
+
+
+def configure_frame_acq_time(new_frame_acq_time):
+    """ function to configure frame acquire time of area detector """
+
+    area_det = xpd_device['area_det']
+    # stop acquisition
+    area_det.cam.acquire.put(0)
+    time.sleep(1)
+    area_det.number_of_sets.put(1)
+    area_det.cam.acquire_time.put(val)
+    # extra wait time for device to set
+    time.sleep(1)
+    area_det.cam.acquire.put(1)
+    print("INFO: area detector has been configured to new"
+          " exposure_time = {}s".format(new_frame_acq_time))
+
+
+class GlblYamlDict(YamlDict):
+    """ class holds global options of xpdAcq.
+
+    It automatically update yaml file when contents are changed,
+    and for back-support, it issues a Deprecationwarning when user tries
+    to set attributes
+
+    Parameters:
+    -----------
+    name : str
+        name of this object. It's *suggested* to be the same as
+        the instance name. i.e. glbl = GlblYamlDict('glbl', *kwargs...)
+    kwargs :
+        keyword arguments for global options
+    """
+    # required attributes for yaml
+    VALID_ATTRS = ['_name', '_filepath', 'filepath', '_referenced_by']
+
+    # keys for fileds allowed to change
+    ALLOWED_KEYS = ['det_image_field', 'auto_dark',
+                    'dk_window', 'shutter_control']
+
+    def __init__(self, name, **kwargs):
+        super().__init__(name=name,**kwargs)
+        self._referenced_by = []
+        self._name = name
+
+    def default_yaml_path(self):
+        return os.path.join(os.getcwd(), 'glbl_test.yml')
+
+    def __setitem__(self, key, val):
+        if key not in self.ALLOWED_KEYS:
+            e = "{} doesn't correspond to a valid key".format(key)
+            print("List of valid keys is:\n"
+                  "\n{}".format('\n'.join(self.ALLOWED_KEYS)))
+            raise KeyError(e)
+        else:
+            super().__setitem__(key, val)
+
+    def __setattr__(self, key, val):
+        if key not in self.VALID_ATTRS:
+            if key in (self.ALLOWED_KEYS):
+                # back-support
+                raise DeprecationWarning("{} has been changed, please do "
+                                         "this command instead\n"
+                                         ">>> {}['{}']={}"
+                                         .format(self._name,
+                                                 self._name,
+                                                 key, val))
+            else:
+                raise AttributeError("{} doesn't support attribute"
+                                     .format(self._name))
+        else:
+            super().__setattr__(key, val)
+
+    @classmethod
+    def from_yaml(cls, f):
+        d = yaml.load(f)
+        instance = cls.from_dict(d)
+        if not isinstance(f, str):
+            instance.filepath = os.path.abspath(f.name)
+        return instance
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)

--- a/xpdacq/glbl.py
+++ b/xpdacq/glbl.py
@@ -217,3 +217,5 @@ class GlblYamlDict(YamlDict):
         return cls(**d)
 
 glbl = GlblYamlDict('glbl', **glbl_dict)
+# Possible config:
+# full_xpdAcq_config = ChainMap(glbl, xpd_device)

--- a/xpdacq/simulation.py
+++ b/xpdacq/simulation.py
@@ -158,7 +158,8 @@ def insert_imgs(mds, fs, n, shape, save_dir=tempfile.mkdtemp()):
 
 
 # create objects
+# FIXME: in the future, these creations should go to xpdSim
 pe1c = SimulatedPE1C('pe1c', {'pe1_image': lambda: 5})
 shutter = be.Mover('motor', {'motor': lambda x: x}, {'x': 0})
 db = build_pymongo_backed_broker()
-insert_imgs(db.mds, db.fs, 1, (2048,2048), save_dir=tempfile.mkdtemp()):
+insert_imgs(db.mds, db.fs, 1, (2048,2048), save_dir=tempfile.mkdtemp())

--- a/xpdacq/simulation.py
+++ b/xpdacq/simulation.py
@@ -8,26 +8,7 @@ from time import strftime
 from tifffile import imread
 from unittest.mock import MagicMock
 
-
-from .glbl import glbl
 import bluesky.examples as be
-
-
-
-def start_simulation(glbl=glbl):
-    # mock imports
-    glbl.db = build_pymongo_backed_broker()
-    glbl.get_events = glbl.db.get_events
-    glbl.get_images = glbl.db.get_images
-    glbl.verify_files_saved = MagicMock()
-    # mock collection objects
-    glbl.area_det = SimulatedPE1C('pe1c', {'pe1_image': lambda: 5})
-    glbl.temp_controller = be.motor
-    glbl.shutter = MagicMock()
-    glbl.ring_current = MagicMock()
-    print('==== Simulation being created in current directory:{} ===='
-          .format(glbl.base))
-    os.makedirs(glbl.home, exist_ok=True)
 
 
 # define simulated PE1C
@@ -174,3 +155,10 @@ def insert_imgs(mds, fs, n, shape, save_dir=tempfile.mkdtemp()):
                         uid=str(uuid.uuid4()),
                         time=time.time())
     return save_dir
+
+
+# create objects
+pe1c = SimulatedPE1C('pe1c', {'pe1_image': lambda: 5})
+shutter = be.Mover('motor', {'motor': lambda x: x}, {'x': 0})
+db = build_pymongo_backed_broker()
+insert_imgs(db.mds, db.fs, 1, (2048,2048), save_dir=tempfile.mkdtemp()):

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -10,9 +10,9 @@ from bluesky import RunEngine
 from bluesky.utils import normalize_subs_input
 from bluesky.suspenders import SuspendFloor
 
-from .glbl import glbl
-from .yamldict import YamlDict, YamlChainMap
-from .beamtime import *
+from xpdacq.glbl import glbl
+from xpdacq.yamldict import YamlDict, YamlChainMap
+from xpdacq.beamtime import *
 
 from xpdan.tools import compress_mask
 


### PR DESCRIPTION
This is a PR to share idea, not aiming for pulling at this stage (syntax updates are needed if we are heading this direction).

This refactoring would introduce following features

1. ``glbl`` now behaves like ``Beamtime`` object. Every time allowed key is updated, it automatically serializes the change so that makes reload of ``dark_window`` and other configurations possible. (address #292)

2.  As ``glbl`` now behaves like ``Beamtime``, it is also possible to ``an_glbl`` behaves like ``Sample`` objects (i.e. make them as a ``ChainMap``). In this way, we can reproduce the functionality of propagating updates to both objects once content from either of them is updated. 
[xpdAn issue 30](https://github.com/xpdAcq/xpdAn/issues/30) 

3. prevent user from setting arbitrary attributes, like ``glbl.apple = orange``(which is currently possible)

4. We can also make ``glbl`` as a ``ChaiMap`` with another ``dict`` contains required device objects. So we can potentially adopt the suggestion mentioned in 
[xpdAn issue 29](https://github.com/xpdAcq/xpdAn/issues/29), then we reduce the possibility of maintaining contents inside startup directory.

Any thught or suggestions?  @tacaswell @danielballan @sbillinge @CJ-Wright 

Thanks