### PR TITLE
Fix bt.list

### DIFF
--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -338,12 +338,12 @@ def _clean_info(obj):
     """ stringtify and replace space"""
     return str(obj).strip().replace(' ', '_')
 
-class MDOrderedDict(OrderedDict):
-    def get_md(self, ind):
-        """ special method to get metadata of a objects inside a dict """
-        obj_list = list(self.values())
-        md_dict = dict(obj_list[ind])
-        return md_dict
+
+class SliceableOrderedDict(OrderedDict):
+    def get_slice(self, ind):
+        """method to return value of OrderedDict based on index"""
+        val_list = list(self.values())
+        return dict(val_list[ind])
 
 
 class Beamtime(ValidatedDictLike, YamlDict):
@@ -392,8 +392,8 @@ class Beamtime(ValidatedDictLike, YamlDict):
                          bt_experimenters=experimenters,
                          bt_wavelength=wavelength, **kwargs)
         self._wavelength = wavelength
-        self.scanplans = MDOrderedDict()
-        self.samples = MDOrderedDict()
+        self.scanplans = SliceableOrderedDict()
+        self.samples = SliceableOrderedDict()
         self._referenced_by = []
         # used by YamlDict when reload
         self.setdefault('bt_uid', new_short_uid())

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -431,7 +431,7 @@ class Beamtime(ValidatedDictLike, YamlDict):
         # yaml sync list
         self._referenced_by.append(scanplan)
         # save order
-        with open(os.path.join(glbl.config_base,
+        with open(os.path.join(glbl['config_base'],
                                '.scanplan_order.yml'),'w+') as f:
             scanplan_order = {}
             for i, name in enumerate(self.scanplans.keys()):
@@ -448,7 +448,7 @@ class Beamtime(ValidatedDictLike, YamlDict):
         # yaml sync list
         self._referenced_by.append(sample)
         # save order
-        with open(os.path.join(glbl.config_base,
+        with open(os.path.join(glbl['config_base'],
                                '.sample_order.yml'),'w+') as f:
             sample_order = {}
             for i, name in enumerate(self.samples.keys()):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -430,6 +430,15 @@ class Beamtime(ValidatedDictLike, YamlDict):
         self.scanplans.update({scanplan_name: scanplan})
         # yaml sync list
         self._referenced_by.append(scanplan)
+        # save order
+        with open(os.path.join(glbl.config_base,
+                               '.scanplan_order.yml'),'w+') as f:
+            scanplan_order = {}
+            for i, name in enumerate(self.scanplans.keys()):
+                scanplan_order.update({i: name+'.yml'})
+            # debug line
+            self._scanplan_order = scanplan_order
+            yaml.dump(scanplan_order, f)
 
     def register_sample(self, sample):
         # Notify this Beamtime about an Sample that should be re-synced
@@ -438,6 +447,15 @@ class Beamtime(ValidatedDictLike, YamlDict):
         self.samples.update({sample_name: sample})
         # yaml sync list
         self._referenced_by.append(sample)
+        # save order
+        with open(os.path.join(glbl.config_base,
+                               '.sample_order.yml'),'w+') as f:
+            sample_order = {}
+            for i, name in enumerate(self.samples.keys()):
+                sample_order.update({i: name+'.yml'})
+            # debug line
+            self._sample_order = sample_order
+            yaml.dump(sample_order, f)
 
     @classmethod
     def from_yaml(cls, f):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -338,13 +338,12 @@ def _clean_info(obj):
     """ stringtify and replace space"""
     return str(obj).strip().replace(' ', '_')
 
-
-class SliceableOrderedDict(OrderedDict):
-    def get_slice(self, ind):
-        """method to return value of OrderedDict based on index"""
-        val_list = list(self.values())
-        return dict(val_list[ind])
-
+class MDOrderedDict(OrderedDict):
+    def get_md(self, ind):
+        """ special method to get metadata of a objects based on index """
+        obj_list = list(self.values())
+        md_dict = dict(obj_list[ind])
+        return md_dict
 
 class Beamtime(ValidatedDictLike, YamlDict):
     """

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -391,8 +391,8 @@ class Beamtime(ValidatedDictLike, YamlDict):
                          bt_experimenters=experimenters,
                          bt_wavelength=wavelength, **kwargs)
         self._wavelength = wavelength
-        self.scanplans = SliceableOrderedDict()
-        self.samples = SliceableOrderedDict()
+        self.scanplans = MDOrderedDict()
+        self.samples = MDOrderedDict()
         self._referenced_by = []
         # used by YamlDict when reload
         self.setdefault('bt_uid', new_short_uid())

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -397,8 +397,6 @@ class Beamtime(ValidatedDictLike, YamlDict):
         self._referenced_by = []
         # used by YamlDict when reload
         self.setdefault('bt_uid', new_short_uid())
-        self.setdefault('_sample_order', {})
-        self.setdefault('_scanplan_order', {})
 
     @property
     def wavelength(self):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -340,7 +340,9 @@ def _clean_info(obj):
 
 class MDOrderedDict(OrderedDict):
     def get_md(self, ind):
-        """ special method to get metadata of a objects based on index """
+        """special method to get metadata of sample object based on
+        bt.list index
+        """
         obj_list = list(self.values())
         md_dict = dict(obj_list[ind])
         return md_dict

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -17,8 +17,9 @@ import os
 import uuid
 import yaml
 import inspect
-from collections import ChainMap
+from collections import ChainMap, OrderedDict
 
+import bluesky.plans as bp
 import numpy as np
 import bluesky.plans as bp
 from bluesky.callbacks import LiveTable
@@ -337,6 +338,13 @@ def _clean_info(obj):
     """ stringtify and replace space"""
     return str(obj).strip().replace(' ', '_')
 
+class MDOrderedDict(OrderedDict):
+    def get_md(self, ind):
+        """ special method to get metadata of a objects inside a dict """
+        obj_list = list(self.values())
+        md_dict = dict(obj_list[ind])
+        return md_dict
+
 
 class Beamtime(ValidatedDictLike, YamlDict):
     """
@@ -384,12 +392,13 @@ class Beamtime(ValidatedDictLike, YamlDict):
                          bt_experimenters=experimenters,
                          bt_wavelength=wavelength, **kwargs)
         self._wavelength = wavelength
-        # self.experiments = []
-        self.scanplans = []
-        self.samples = []
+        self.scanplans = MDOrderedDict()
+        self.samples = MDOrderedDict()
         self._referenced_by = []
-        # used by YamlDict
+        # used by YamlDict when reload
         self.setdefault('bt_uid', new_short_uid())
+        self.setdefault('_sample_order', {})
+        self.setdefault('_scanplan_order', {})
 
     @property
     def wavelength(self):
@@ -401,25 +410,6 @@ class Beamtime(ValidatedDictLike, YamlDict):
     def wavelength(self, val):
         self._wavelength = val
         self.update(bt_wavelength=val)
-
-    def register_scanplan(self, scanplan):
-        # Notify this Beamtime about an ScanPlan that should be re-synced
-        # whenever the contents of the Beamtime are edited.
-        sp_name_list = [el.short_summary() for el in self.scanplans]
-        # manage bt.list
-        if scanplan.short_summary() not in sp_name_list:
-            self.scanplans.append(scanplan)
-        else:
-            old_obj = [obj for obj in self.scanplans if
-                       obj.short_summary() == scanplan.short_summary()].pop()
-            old_obj_ind = self.scanplans.index(old_obj)
-            self.scanplans.remove(old_obj)
-            self.scanplans.insert(old_obj_ind, scanplan)
-        # yaml sync list
-        # simply append object to list to increase speed
-        #self._referenced_by.extend([el for el in self.scanplans if el
-        #                            not in self._referenced_by])
-        self._referenced_by.append(scanplan)
 
     @property
     def md(self):
@@ -436,26 +426,20 @@ class Beamtime(ValidatedDictLike, YamlDict):
         return os.path.join(glbl['yaml_dir'],
                             'bt_bt.yml').format(**self)
 
+    def register_scanplan(self, scanplan):
+        # Notify this Beamtime about an ScanPlan that should be re-synced
+        # whenever the contents of the Beamtime are edited. 
+        scanplan_name = scanplan.short_summary()
+        self.scanplans.update({scanplan_name: scanplan})
+        # yaml sync list
+        self._referenced_by.append(scanplan)
+
     def register_sample(self, sample):
         # Notify this Beamtime about an Sample that should be re-synced
         # whenever the contents of the Beamtime are edited.
-        sa_name_list = [el.get('sample_name', None) for el in self.samples]
-        # manage bt.list
-        if sample.get('sample_name') not in sa_name_list:
-            self.samples.append(sample)
-        else:
-            old_obj = [obj for obj in self.samples if obj.get('sample_name') ==
-                       sample.get('sample_name')].pop()
-            old_obj_ind = self.samples.index(old_obj)
-            self.samples.remove(old_obj)
-            self.samples.insert(old_obj_ind, sample)
+        sample_name = sample.get('sample_name', None)
+        self.samples.update({sample_name: sample})
         # yaml sync list
-        # simply append object to list to increase speed
-        # filtering logic is handle when importing sample
-        #self._referenced_by.extend([el for el in self.samples if el
-        #                            not in self._referenced_by])
-        # simply append object to list to increase speed
-        # filtering logic is handle when importing sample
         self._referenced_by.append(sample)
 
     @classmethod
@@ -477,12 +461,13 @@ class Beamtime(ValidatedDictLike, YamlDict):
 
     def __str__(self):
         contents = (['', 'ScanPlans:'] +
-                    ['{i}: {sp!r}'.format(i=i, sp=sp.short_summary())
-                     for i, sp in enumerate(self.scanplans)] +
+                    ['{}: {}'.format(i, sp_name)
+                     for i, sp_name in enumerate(self.scanplans.keys())] +
                     ['', 'Samples:'] +
-                    ['{i}: {sample_name}'.format(i=i, **s)
-                     for i, s in enumerate(self.samples)])
+                    ['{}: {}'.format(i, sa_name)
+                     for i, sa_name in enumerate(self.samples.keys())])
         return '\n'.join(contents)
+
 
     def list(self):
         """ method to list out all ScanPlan and Sample objects related
@@ -494,9 +479,10 @@ class Beamtime(ValidatedDictLike, YamlDict):
     def list_bkg(self):
         """ method to list background object only """
 
-        contents = ['', 'Background:'] + ['{i}: {sample_name}'.format(i=i, **s)
-                                          for i, s in enumerate(self.samples)
-                                          if s['sample_name'].startswith('bkgd')]
+        contents = ['', 'Background:'] + ['{}: {}'.format(i, sa_name)
+                                          for i, sa_name in
+                                          enumerate(self.samples.keys())
+                                          if sa_name.startswith('bkgd')]
         print('\n'.join(contents))
 
 class Sample(ValidatedDictLike, YamlChainMap):

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -127,11 +127,19 @@ def load_beamtime(directory=None):
     with open(beamtime_fn, 'r') as f:
         bt = load_yaml(f, known_uids)
 
-    for fn in scanplan_fns:
+    # get the most recent order
+    with open(os.path.join(glbl.config_base,
+                           '.scanplan_order.yml')) as f:
+        scanplan_order = yaml.load(f)
+    with open(os.path.join(glbl.config_base,
+                           '.sample_order.yml')) as f:
+        sample_order = yaml.load(f)
+
+    for fn in sorted(scanplan_fns, key=list(scanplan_order.values()).index):
         with open(os.path.join(directory, 'scanplans', fn), 'r') as f:
             load_yaml(f, known_uids)
 
-    for fn in sample_fns:
+    for fn in sorted(sample_fns, key=list(sample_order.values()).index):
         with open(os.path.join(directory, 'samples', fn), 'r') as f:
             load_yaml(f, known_uids)
 

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -128,10 +128,10 @@ def load_beamtime(directory=None):
         bt = load_yaml(f, known_uids)
 
     # get the most recent order
-    with open(os.path.join(glbl.config_base,
+    with open(os.path.join(glbl_dict['config_base'],
                            '.scanplan_order.yml')) as f:
         scanplan_order = yaml.load(f)
-    with open(os.path.join(glbl.config_base,
+    with open(os.path.join(glbl_dict['config_base'],
                            '.sample_order.yml')) as f:
         sample_order = yaml.load(f)
 

--- a/xpdacq/tests/test_beamtime.py
+++ b/xpdacq/tests/test_beamtime.py
@@ -238,7 +238,7 @@ class BeamtimeObjTest(unittest.TestCase):
 
         bt2 = load_beamtime()
         self.assertEqual(bt2, bt)
-        self.assertEqual(bt2.samples[0], sa)
+        self.assertEqual(list(bt2.samples.values())[0], sa)
 
     def test_list_bkg_smoke(self):
         bt = Beamtime('Simon', 123, [], wavelength=0.1828, custom1='A')

--- a/xpdacq/tests/test_beamtimeSetup.py
+++ b/xpdacq/tests/test_beamtimeSetup.py
@@ -93,7 +93,8 @@ class NewBeamtimeTest(unittest.TestCase):
         self.assertEqual(os.getcwd(), self.home_dir)
         # test prepoluate ScanPlan
         self.assertEqual(len(self.bt.scanplans), len(EXPO_LIST))
-        for sp, expect_arg in zip(self.bt.scanplans, EXPO_LIST):
+        for sp, expect_arg in zip(list(self.bt.scanplans.values()),
+                                  EXPO_LIST):
             self.assertEqual(sp['sp_args'], (expect_arg,))
         # test if yml files are saved properly
         for expo in EXPO_LIST:
@@ -101,7 +102,7 @@ class NewBeamtimeTest(unittest.TestCase):
                                   'ct_{}.yml'.format(expo))
             self.assertTrue(os.path.isfile(f_path))
         # test if it can be reloaded
-        for current_sp in self.bt.scanplans:
+        for current_sp in self.bt.scanplans.values():
             reload_sp = ScanPlan.from_yaml(current_sp.to_yaml())
             self.assertEqual(reload_sp, current_sp)
             self.assertFalse(id(reload_sp) ==  id(current_sp))

--- a/xpdacq/tests/test_import_sample_info.py
+++ b/xpdacq/tests/test_import_sample_info.py
@@ -56,7 +56,7 @@ class ImportSamplTest(unittest.TestCase):
         # expect to pass with explicit argument
         _import_sample_info(300000, self.bt)
         # check imported sample metadata
-        for sample in self.bt.samples:
+        for sample in self.bt.samples.values():
             # Sample is a ChainMap with self.maps[1] == bt
             self.assertEqual(sample.maps[1], self.bt)
 

--- a/xpdacq/tests/test_import_sample_info.py
+++ b/xpdacq/tests/test_import_sample_info.py
@@ -69,3 +69,8 @@ class ImportSamplTest(unittest.TestCase):
 
         # expct TypeError with incorrect beamtime
         self.assertRaises(TypeError, lambda: _import_sample_info(bt=set()))
+
+        # test get_md_method
+        sample_obj_list = [el for el in self.bt.samples.values()]
+        for i, el in enumerate(sample_obj_list):
+            self.assertEqual(dict(el), self.bt.samples.get_md(i))

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -26,7 +26,7 @@ import pandas as pd
 
 from .glbl import glbl
 from .tools import _check_obj, _graceful_exit
-from .beamtime import Beamtime, Sample, ScanPlan
+from .beamtime import Beamtime, Sample
 
 def composition_analysis(compstring):
     """Pulls out elements and their ratios from the config file.

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -530,11 +530,6 @@ def _import_sample_info(saf_num=None, bt=None):
             return
     print('INFO: using SAF_number = {}'.format(saf_num))
 
-    bt.samples = []
-    # exclude Sample objects from reference list
-    # logic: only update Sample objects that are currently in bt.list
-    sp_ref = [el for el in bt._referenced_by if isinstance(el, ScanPlan)]
-    bt._referenced_by = sp_ref
     excel_to_yaml.load(saf_num)
     excel_to_yaml.create_yaml(bt)
     return excel_to_yaml

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -322,7 +322,7 @@ class CustomizedRunEngine(RunEngine):
 
         if isinstance(sample, int):
             try:
-                sample = self.beamtime.samples[sample]
+                sample = list(self.beamtime.samples.values())[sample]
             except IndexError:
                 print("WARNING: hmm, there is no sample with index `{}`"
                       ", please do `bt.list()` to check if it exists yet"
@@ -331,7 +331,7 @@ class CustomizedRunEngine(RunEngine):
         # If a plan is given as a string, look in up in the global registry.
         if isinstance(plan, int):
             try:
-                plan = self.beamtime.scanplans[plan]
+                plan = list(self.beamtime.scanplans.values())[plan]
             except IndexError:
                 print("WARNING: hmm, there is no scanplan with index `{}`"
                       ", please do `bt.list()` to check if it exists yet"

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -297,7 +297,6 @@ class CustomizedRunEngine(RunEngine):
         self._beamtime = bt_obj
         self.md.update(bt_obj.md)
         print("INFO: beamtime object has been linked\n")
-        # from xpdacq.calib import run_calibration
         if not glbl['is_simulation']:
             pass
             # let user deal with suspender


### PR DESCRIPTION
closes #233 

Turn ``bt.samples`` and ``bt.scanplans`` into ``OrderedDict`` so that metadata will only be updated, not refreshed when redo ``import_sample_info``.

Also added sorting logic to reload sequence. In this way, we can make sure indices in ``bt.list`` remain unchanged after exit and come back to ipython
