### PR TITLE
Fix md parser

### DIFF
--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -8,6 +8,7 @@ import numpy as np
 from bluesky.callbacks import LiveTable
 
 from .glbl import glbl
+from .tools import clean_dict
 from .yamldict import YamlDict, YamlChainMap
 from .validated_dict import ValidatedDictLike
 
@@ -508,12 +509,12 @@ class Sample(ValidatedDictLike, YamlChainMap):
     _REQUIRED_FIELDS = ['sample_name', 'sample_composition']
 
     def __init__(self, beamtime, sample_md, **kwargs):
-        composition = sample_md.get('sample_composition', None)
-        # print("composition of {} is {}".format(sample_md['sample_name'],
-        #                                       sample_md['sample_composition']))
+        # clean dict before instantiation
+        clean_dict(sample_md, '.', ',')
         try:
             super().__init__(sample_md, beamtime)  # ChainMap signature
         except:
+            composition = sample_md.get('sample_composition', None)
             print("At least sample_name and sample_composition is needed.\n"
                   "For example\n"
                   ">>> sample_md = {'sample_name':'Ni',"

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -8,7 +8,7 @@ import numpy as np
 from bluesky.callbacks import LiveTable
 
 from .glbl import glbl
-from .tools import clean_dict
+from .tools import regularize_dict_key
 from .yamldict import YamlDict, YamlChainMap
 from .validated_dict import ValidatedDictLike
 
@@ -510,7 +510,7 @@ class Sample(ValidatedDictLike, YamlChainMap):
 
     def __init__(self, beamtime, sample_md, **kwargs):
         # clean dict before instantiation
-        clean_dict(sample_md, '.', ',')
+        regularize_dict_key(sample_md, '.', ',')
         try:
             super().__init__(sample_md, beamtime)  # ChainMap signature
         except:

--- a/xpdacq/tests/test_tools.py
+++ b/xpdacq/tests/test_tools.py
@@ -1,5 +1,5 @@
 import pytest
-from xpdacq.tools import clean_dict
+from xpdacq.tools import regularize_dict_key
 
 @pytest.mark.parametrize("input_dict, output_dict",
                          [({'a': 1, 'b': 2, 'c': 3},
@@ -11,6 +11,6 @@ from xpdacq.tools import clean_dict
                           ({'a.foo': {'b.bar': '2.foo'}, 'c': '3.bar'},
                            {'a,foo': {'b,bar': '2.foo'}, 'c': '3.bar'})
                          ])
-def test_clean_dict(input_dict, output_dict):
-    clean_dict(input_dict, '.', ',')  # modify dict in place
+def test_regularize_dict_key(input_dict, output_dict):
+    regularize_dict_key(input_dict, '.', ',')  # modify dict in place
     assert input_dict == output_dict  # test equality

--- a/xpdacq/tests/test_tools.py
+++ b/xpdacq/tests/test_tools.py
@@ -1,19 +1,17 @@
+import pytest
+import copy
 from xpdacq.tools import clean_dict
 
-def test_clean_dict():
-    # case 1: oridinary dict, no changes
-    test = {'a': 1, 'b': 2, 'c': 3}
-    clean_dict(test, '.', ',')
-    assert test == {'a': 1, 'b': 2, 'c': 3}
-    # case 2: flat dict with target character
-    test = {'a.foo': 1, 'b.bar': 2, 'c': 3}
-    clean_dict(test, '.', ',')
-    assert test == {'a,foo': 1, 'b,bar': 2, 'c': 3}
-    # case 3: nested dict with target character
-    test = {'a.foo': {'b.bar': 2}, 'c': 3}
-    clean_dict(test, '.', ',')
-    assert test == {'a,foo': {'b,bar': 2}, 'c': 3}
-    # case 4: nested dict with target character, both key and val
-    test = {'a.foo': {'b.bar': '2.foo'}, 'c': '3.bar'}
-    clean_dict(test, '.', ',')
-    assert test == {'a,foo': {'b,bar': '2.foo'}, 'c': '3.bar'}
+@pytest.mark.parametrize("input_dict, output_dict",
+                         [({'a': 1, 'b': 2, 'c': 3},
+                           {'a': 1, 'b': 2,'c':3}),
+                          ({'a.foo': 1, 'b.bar': 2, 'c': 3},
+                           {'a,foo': 1, 'b,bar': 2, 'c': 3}),
+                          ({'a.foo': {'b.bar': 2}, 'c': 3},
+                           {'a,foo': {'b,bar': 2}, 'c': 3}),
+                          ({'a.foo': {'b.bar': '2.foo'}, 'c': '3.bar'},
+                           {'a,foo': {'b,bar': '2.foo'}, 'c': '3.bar'})
+                         ])
+def test_clean_dict(input_dict, output_dict):
+    clean_dict(input_dict, '.', ',')  # modify dict in place
+    assert input_dict == output_dict  # test equality

--- a/xpdacq/tests/test_tools.py
+++ b/xpdacq/tests/test_tools.py
@@ -1,0 +1,19 @@
+from xpdacq.tools import clean_dict
+
+def test_clean_dict():
+    # case 1: oridinary dict, no changes
+    test = {'a': 1, 'b': 2, 'c': 3}
+    clean_dict(test, '.', ',')
+    assert test == {'a': 1, 'b': 2, 'c': 3}
+    # case 2: flat dict with target character
+    test = {'a.foo': 1, 'b.bar': 2, 'c': 3}
+    clean_dict(test, '.', ',')
+    assert test == {'a,foo': 1, 'b,bar': 2, 'c': 3}
+    # case 3: nested dict with target character
+    test = {'a.foo': {'b.bar': 2}, 'c': 3}
+    clean_dict(test, '.', ',')
+    assert test == {'a,foo': {'b,bar': 2}, 'c': 3}
+    # case 4: nested dict with target character, both key and val
+    test = {'a.foo': {'b.bar': '2.foo'}, 'c': '3.bar'}
+    clean_dict(test, '.', ',')
+    assert test == {'a,foo': {'b,bar': '2.foo'}, 'c': '3.bar'}

--- a/xpdacq/tests/test_tools.py
+++ b/xpdacq/tests/test_tools.py
@@ -1,10 +1,9 @@
 import pytest
-import copy
 from xpdacq.tools import clean_dict
 
 @pytest.mark.parametrize("input_dict, output_dict",
                          [({'a': 1, 'b': 2, 'c': 3},
-                           {'a': 1, 'b': 2,'c':3}),
+                           {'a': 1, 'b': 2, 'c': 3}),
                           ({'a.foo': 1, 'b.bar': 2, 'c': 3},
                            {'a,foo': 1, 'b,bar': 2, 'c': 3}),
                           ({'a.foo': {'b.bar': 2}, 'c': 3},

--- a/xpdacq/tools.py
+++ b/xpdacq/tools.py
@@ -13,7 +13,7 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-def clean_dict(input_dict, target_chr, replace_chr):
+def regularize_dict_key(input_dict, target_chr, replace_chr):
     """recursively replace target character in keys with desired one
 
     Parameters
@@ -29,7 +29,7 @@ def clean_dict(input_dict, target_chr, replace_chr):
         if isinstance(v, dict):
             clean_k = k.replace(target_chr, replace_chr)
             input_dict[clean_k] = input_dict.pop(k)
-            clean_dict(v, target_chr, replace_chr)
+            regularize_dict_key(v, target_chr, replace_chr)
         else:
             clean_k = k.replace(target_chr, replace_chr)
             input_dict[clean_k] = input_dict.pop(k)

--- a/xpdacq/tools.py
+++ b/xpdacq/tools.py
@@ -25,7 +25,6 @@ def clean_dict(input_dict, target_chr, replace_chr):
     replace_chr : str
         character that is going to replace target character
     """
-    # for safety, copy a new one
     for k, v in input_dict.items():
         if isinstance(v, dict):
             clean_k = k.replace(target_chr, replace_chr)

--- a/xpdacq/tools.py
+++ b/xpdacq/tools.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# xpdacq            by Billinge Group
+#                   Simon J. L. Billinge sb2896@columbia.edu
+#                   (c) 2016 trustees of Columbia University in the City of
+#                        New York.
+#                   All rights reserved
+#
+# File coded by:    Timothy Liu
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
+def clean_dict(input_dict, target_chr, replace_chr):
+    """recursively replace target character in keys with desired one
+
+    Parameters
+    ----------
+    input_dict : dict
+        a dictionary going to be cleaned. it could be nested
+    target_chr : str
+        character that will be placed
+    replace_chr : str
+        character that is going to replace target character
+    """
+    # for safety, copy a new one
+    for k, v in input_dict.items():
+        if isinstance(v, dict):
+            clean_dict(v, target_chr, replace_chr)
+        else:
+            clean_k = k.replace(target_chr, replace_chr)
+            input_dict[clean_k] = input_dict.pop(k)

--- a/xpdacq/tools.py
+++ b/xpdacq/tools.py
@@ -19,9 +19,9 @@ def clean_dict(input_dict, target_chr, replace_chr):
     Parameters
     ----------
     input_dict : dict
-        a dictionary going to be cleaned. it could be nested
+        a dictionary going to be cleaned. it can be nested
     target_chr : str
-        character that will be placed
+        character that will be replaced
     replace_chr : str
         character that is going to replace target character
     """

--- a/xpdacq/tools.py
+++ b/xpdacq/tools.py
@@ -28,6 +28,8 @@ def clean_dict(input_dict, target_chr, replace_chr):
     # for safety, copy a new one
     for k, v in input_dict.items():
         if isinstance(v, dict):
+            clean_k = k.replace(target_chr, replace_chr)
+            input_dict[clean_k] = input_dict.pop(k)
             clean_dict(v, target_chr, replace_chr)
         else:
             clean_k = k.replace(target_chr, replace_chr)


### PR DESCRIPTION
closes #283 

as per discussion, add a helper function to recursively replace ``.`` with ``,`` in key fields to avoid error when interacting with ``mongo``