### PR TITLE
DOC: fix typo in the beamline staff cheatsheet

### DIFF
--- a/doc/sb_cheat_sheet.rst
+++ b/doc/sb_cheat_sheet.rst
@@ -40,7 +40,7 @@ where the <saf_number> must match that of the current beamtime.  If the user did
 
 .. code-block:: python
 
-  load_sample_info()
+  import_sample_info()
 
 .. Note::
 


### PR DESCRIPTION
update typo in beamline staff cheatsheet