### PR TITLE
Enh endbeamtime v2

### DIFF
--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -193,11 +193,12 @@ def _end_beamtime(base_dir=None, archive_dir=None, bto=None, usr_confirm='y'):
     """ funciton to end a beamtime.
 
     Detail steps are:
-        2) Arhcive ``xpdUser`` directory to remove backup
+        2) Archive ``xpdUser`` directory to remove backup
         3) Ask for user confirmation
         4.1) if user confirms, flush all sub-directories under
         ``xpdUser`` for a new beamtime.
-        4.2) if user doesn't confirm, leave ``xpdUser`` untouched.
+        4.2) if user disagree, leave ``xpdUser`` untouched and flush
+        remote backup to avoid duplicate archives.
     """
     # NOTE: to avoid network bottleneck, we actually only move all files
     # except for .tif.
@@ -264,7 +265,7 @@ def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
     try:
         os.chdir(root_dir)
         print("INFO: Archiving your data now. That may take several"
-              " minutes. please be patient :)")
+              " minutes. Please be patient :)")
         # remove dir structure would be:
         # <remote>/<PI_last+uid>/xpdUser/....
         os.makedirs(archive_full_name, exist_ok=True)
@@ -282,7 +283,7 @@ def _load_bt(bt_yaml_path):
     if not os.path.isfile(btoname):
         sys.exit(_graceful_exit("{} does not exist in {}. User might have"
                                 "deleted it accidentally.Please create it"
-                                "based on user information or contect user"
+                                "based on user information or contact user"
                                 .format(os.path.basename(btoname),
                                         glbl_dict['yaml_dir'])))
     with open(btoname, 'r') as f:
@@ -309,8 +310,8 @@ def _confirm_archive(archive_f_name):
     else:
         # flush remote backup
         shutil.rmtree(archive_f_name)
-        sys.exit(_graceful_exit("xpdUser directory delete operation cancelled."
-                                "at Users request"))
+        sys.exit(_graceful_exit("xpdUser directory delete operation cancelled "
+                                "at Users request."))
 
 def _delete_home_dir_tree():
     os.chdir(glbl_dict['base'])  # move out from xpdUser before deletion

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -315,9 +315,25 @@ def _confirm_archive(archive_f_name):
 
 def _delete_home_dir_tree():
     os.chdir(glbl_dict['base'])  # move out from xpdUser before deletion
-    shutil.rmtree(glbl_dict['home'])
-    os.makedirs(glbl_dict['home'])
-    os.chdir(glbl_dict['home'])  # now move back into xpdUser
+    dir_to_flush = glbl_dict['home']
+    while os.path.isdir(dir_to_flush):
+        try:
+            shutil.rmtree(dir_to_flush)
+        except:
+            # TODO: error is platform-dependent. might want to
+            #discuss if we need to specify error type.
+            print("INFO: Some files are still used by the current "
+                  "process.\nIt could be the sample spreadsheet "
+                  "located in ``xpdUser/Import`` directory or "
+                  "could be python script opened in editors.\n"
+                  "Please find all possible files and close them.")
+            msg = input("INFO: If files are properly closed, "
+                        "please hit any key to continue the end_beamtime "
+                        "process.")
+            if msg:
+                pass
+    os.makedirs(dir_to_flush)
+    os.chdir(dir_to_flush)  # now move back into xpdUser
     return
 
 

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -270,7 +270,7 @@ def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
         # <remote>/<PI_last+uid>/xpdUser/....
         os.makedirs(archive_full_name, exist_ok=True)
         subprocess.run(['rsync', '-av',
-                        '--exclude=*.tif',
+                        #'--exclude=*.tif',  # not used yet
                         glbl_dict['home'], archive_full_name],
                         check=True)
     finally:

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -267,6 +267,7 @@ def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
               " minutes. please be patient :)")
         # remove dir structure would be:
         # <remote>/<PI_last+uid>/xpdUser/....
+        os.makedirs(archive_full_name, exist_ok=True)
         subprocess.run(['rsync', '-av', '--exclude=*.tif',
                         glbl_dict['home'], archive_full_name],
                         check=True)
@@ -295,8 +296,9 @@ def _load_bt(bt_yaml_path):
 
 
 def _get_user_confirmation():
-    conf = input("Please confirm data are backed up. Are you ready to continue"
-                 "with xpdUser directory contents deletion (y,[n])?: ")
+    conf = input("Please confirm data are backed up.\n"
+                 "Are you ready to continue with xpdUser "
+                 "directory contents deletion (y,[n])?: ")
     return conf
 
 
@@ -310,9 +312,10 @@ def _confirm_archive(archive_f_name):
     if conf in ('y', 'Y'):
         return
     else:
+        # flush remote backup
+        shutil.rmtree(archive_f_name)
         sys.exit(_graceful_exit("xpdUser directory delete operation cancelled."
                                 "at Users request"))
-
 
 def _delete_home_dir_tree():
     os.chdir(glbl_dict['base'])  # move out from xpdUser before deletion

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -19,6 +19,7 @@ import yaml
 import shutil
 import subprocess
 from time import strftime
+
 from IPython import get_ipython
 from pkg_resources import resource_filename as rs_fn
 
@@ -260,7 +261,6 @@ def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
                                      archive_name)
     if root_dir is None:
         root_dir = glbl_dict['base']
-    #cur_path = os.getcwd()
     try:
         os.chdir(root_dir)
         print("INFO: Archiving your data now. That may take several"
@@ -268,16 +268,11 @@ def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
         # remove dir structure would be:
         # <remote>/<PI_last+uid>/xpdUser/....
         os.makedirs(archive_full_name, exist_ok=True)
-        subprocess.run(['rsync', '-av', '--exclude=*.tif',
+        subprocess.run(['rsync', '-av',
+                        '--exclude=*.tif',
                         glbl_dict['home'], archive_full_name],
                         check=True)
-        #tar_return = shutil.make_archive(archive_full_name,
-        #                                 archive_format,
-        #                                 root_dir=root_dir,
-        #                                 base_dir='xpdUser', verbose=1,
-        #                                 dry_run=False)
     finally:
-        #os.chdir(cur_path)
         os.chdir(glbl_dict['home'])
     return archive_full_name
 
@@ -351,4 +346,24 @@ def _start_xpdacq():
     else:
         print("INFO: No PI_name has been found")
 
+
+def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
+    archive_full_name = os.path.join(glbl_dict['archive_dir'],
+                                     archive_name)
+    if root_dir is None:
+        root_dir = glbl_dict['base']
+    #cur_path = os.getcwd()
+    try:
+        os.chdir(root_dir)
+        print("INFO: Archiving your data now. That may take several"
+              " minutes. please be patient :)")
+        tar_return = shutil.make_archive(archive_full_name,
+                                         archive_format,
+                                         root_dir=root_dir,
+                                         base_dir='xpdUser', verbose=1,
+                                         dry_run=False)
+    finally:
+        #os.chdir(cur_path)
+        os.chdir(glbl_dict['home'])
+    return archive_full_name
 """

--- a/xpdacq/xpdacq_conf.py
+++ b/xpdacq/xpdacq_conf.py
@@ -70,9 +70,8 @@ else:
 
 if simulation:
     BASE_DIR = os.getcwd()
-    ARCHIVE_BASE_DIR_NAME = 'userBeamtimeArchive'
+    ARCHIVE_BASE_DIR_NAME = 'userSimulationArchive'
     ARCHIVE_BASE_DIR = os.path.join(BASE_DIR, ARCHIVE_BASE_DIR_NAME)
-    USER_BACKUP_DIR_NAME = ARCHIVE_BASE_DIR_NAME
 else:
     BASE_DIR = os.path.abspath('/direct/XF28ID1/pe2_data')
     ARCHIVE_BASE_DIR = os.path.join(os.path.abspath('/direct/XF28ID1/pe1_data'),


### PR DESCRIPTION
This is a PR for issue #399. It implements the workflow of excluding tiffs during archiving. Another approach in the issue #399, leaving another terminal running the end_beamtime, is dangerous as next user might close it anyway and leave the remote backup process incomplete.

This PR also uses ``rsync`` to have nature progress report so that user can know the program is still running. Currently traivs build won't pass as required fixes on the dependencies reside in PR #396. Will rebase after it's merged in.

@sbillinge @CJ-Wright any thought?
also @CJ-Wright we might need to have a simple script for beamline staff to recover all the tiffs if we are going with this end_beamtime approach.

