### PR TITLE
FIX: pure getx3 parser

### DIFF
--- a/xpdacq/tests/test_sample_md_parser.py
+++ b/xpdacq/tests/test_sample_md_parser.py
@@ -16,13 +16,6 @@ from xpdacq.utils import excel_to_yaml
                                                        'Ni': 0.33},
                                                       'H0.66Ni0.33O0.99Ti0.33')
                                 )
-                             , ('TiO2;, H2O:, Ni^1', ({'H': 0.66, 'O': 0.99,
-                                                       'Ti': 0.33, 'Ni': 0.33},
-                                                      {'TiO2': 0.33,
-                                                       'H2O': 0.33,
-                                                       'Ni': 0.33},
-                                                      'H0.66Ni0.33O0.99Ti0.33')
-                                )
                           ])
 def test_phase_str_parser(input_dict, expect_rv):
     assert excel_to_yaml.phase_parser(input_dict) == expect_rv

--- a/xpdacq/tests/test_sample_md_parser.py
+++ b/xpdacq/tests/test_sample_md_parser.py
@@ -8,15 +8,24 @@ from xpdacq.utils import excel_to_yaml
                                                    {'TiO2': 0.33,
                                                     'H2O': 0.33,
                                                     'Ni': 0.33},
-                                                   'H0.66Ni0.33O0.99Ti0.33'))
-                             , ('TiO2:, H2O:, Ni:1', ({'H': 0.66, 'O': 0.99,
-                                                       'Ti': 0.33, 'Ni': 0.33},
-                                                      {'TiO2': 0.33,
-                                                       'H2O': 0.33,
-                                                       'Ni': 0.33},
-                                                      'H0.66Ni0.33O0.99Ti0.33')
-                                )
-                          ])
+                                                   'H0.66Ni0.33O0.99Ti0.33')),
+                          ('TiO2:, H2O:, Ni:1', ({'H': 0.66, 'O': 0.99,
+                                                  'Ti': 0.33, 'Ni': 0.33},
+                                                 {'TiO2': 0.33,
+                                                  'H2O': 0.33,
+                                                  'Ni': 0.33},
+                                                  'H0.66Ni0.33O0.99Ti0.33')),
+                          ('Sr0.52Na0.48X2Q2', ({'Sr': 0.52, 'Na': 0.48,
+                                                'X': 2.0, 'Q': 2.0},
+                                                {'Sr0.52Na0.48X2Q2': 1.0},
+                                                'Na0.48Q2.0Sr0.52X2.0')),
+                          ('X1.1Zn0.9Y0.1E', ({'X': 1.1, 'Zn': 0.9,
+                                               'Y':0.1, 'E': 1.0},
+                                               {'X1.1Zn0.9Y0.1E': 1.0},
+                                               'E1.0X1.1Y0.1Zn0.9'))
+
+                          ]
+                          )
 def test_phase_str_parser(input_dict, expect_rv):
     assert excel_to_yaml.phase_parser(input_dict) == expect_rv
 

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -286,7 +286,8 @@ class ExceltoYaml:
 
                 # other fields don't need to be parsed
                 else:
-                    _k = ''.join(takewhile(lambda x: x.isalpha(), k))
+                    #_k = ''.join(takewhile(lambda x: x.isalpha(), k))
+                    _k = k.replace(' ', '_')
                     parsed_sa_md.update({_k: v})
 
             parsed_sa_md_list.append(parsed_sa_md)
@@ -454,66 +455,53 @@ class ExceltoYaml:
         phase_dict = {}
         composition_dict = {}
         composition_str = ''
-
-        compound_meta = phase_str.split(',')
         # figure out ratio between phases
+        compound_meta = phase_str.split(',')
         for el in compound_meta:
-            el = el.strip()
-            # there is no ":" in the string            
+            _el = el.strip()
             if ':' not in el:
-                # take whatever alpha numeric string before symbol
-                # to be the chemical element
-                symbl = [char for char in el if not char.isalnum()]
-                if symbl:
-                    # take the first symbol
-                    symbl_ind = el.find(symbl[0])
-                    com = el[:symbl_ind]
-                else:
-                    # simply take whole string
-                    com = el
+                # there is no ":" in the string            
                 amount = 1.0
+                com = _el
             else:
-                meta = el.split(':')
+                meta = _el.split(':')
                 # there is a ":" but nothing follows
-                if len(meta[1]) == 0:
+                if not meta[1]:
                     com = meta[0]
                     amount = 1.0
                 # presumably valid input
                 else:
                     com, amount = meta
-            # construct phase dict
-            # DEPRECATED: xpdAcq will move to multiple run_start model
-            # special case: mapping
-            #if com in self.HIGH_D_MD_MAP_KEYWORD:
-            #    phase_dict.update({com.strip(): amount.strip()})
-            #    composition_str = 'N/A'
-            #    composition_dict = {}
-            # normal case, e.g. {'Ni':0.5, 'NaCl':0.5}
+            # further verify if it's giving as 'X: 10%' format
             if isinstance(amount, str):
                 amount = amount.strip()
                 amount = amount.replace('%', '')
-
             # construct the not normalized phase dict
             phase_dict.update({com.strip(): float(amount)})
 
         # normalize phase ratio for composition dict
         total = sum(phase_dict.values())
         for k, v in phase_dict.items():
-            ratio = round(v / total, 2)
+            ratio = round(v / total, 3)
             phase_dict[k] = ratio
 
         # construct composition_dict
         for k, v in phase_dict.items():
-            el_list, sto_list = composition_analysis(k.strip())
+            # k is compostring, v is phase ratio
+            try:
+                el_list, sto_list = composition_analysis(k.strip())
+            except ValueError:
+                # getx3 parser can't parse it, set default
+                el_list, sto_list = ([k], [v])
             for el, sto in zip(el_list, sto_list):
-                # element appears in different phases, adds up
+                # sum element
                 if el in composition_dict:
                     val = composition_dict.get(el)
-                    val += sto * ratio
+                    val += sto * v
                     composition_dict.update({el: val})
                 else:
                     # otherwise, just update it
-                    composition_dict.update({el: sto * ratio})
+                    composition_dict.update({el: sto * v})
 
         # finally, construct composition_str
         for k, v in sorted(composition_dict.items()):

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -461,13 +461,7 @@ class ExceltoYaml:
             _el = el.strip()
             # if no ":" in the string
             if ':' not in _el:
-                # separater instead of ':'
-                if not _el.isalnum():
-                    symbl = [char for char in _el if not char.isalnum()]
-                    symbl_ind = _el.find(symbl[0])
-                    com = _el[:symbl_ind]
-                else:
-                    com = _el
+                com = _el
                 amount = 1.0
             # ":" in the string
             else:

--- a/xpdacq/utils.py
+++ b/xpdacq/utils.py
@@ -459,10 +459,17 @@ class ExceltoYaml:
         compound_meta = phase_str.split(',')
         for el in compound_meta:
             _el = el.strip()
-            if ':' not in el:
-                # there is no ":" in the string            
+            # if no ":" in the string
+            if ':' not in _el:
+                # separater instead of ':'
+                if not _el.isalnum():
+                    symbl = [char for char in _el if not char.isalnum()]
+                    symbl_ind = _el.find(symbl[0])
+                    com = _el[:symbl_ind]
+                else:
+                    com = _el
                 amount = 1.0
-                com = _el
+            # ":" in the string
             else:
                 meta = _el.split(':')
                 # there is a ":" but nothing follows
@@ -482,7 +489,7 @@ class ExceltoYaml:
         # normalize phase ratio for composition dict
         total = sum(phase_dict.values())
         for k, v in phase_dict.items():
-            ratio = round(v / total, 3)
+            ratio = round(v / total, 2)
             phase_dict[k] = ratio
 
         # construct composition_dict


### PR DESCRIPTION
Refactoring on the md parser. Use ``diffpy.getX3`` as final parser, this should deal with edge case of the composition information we had before.
