### PR TITLE
DEP: insert mask in xrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   # make sure the sqlite file exists to avoid race conditions
   - python -c "from bluesky.utils import get_history; get_history()"
   # make sure package data is correctly set
-  - python -c "from xpdsim import xpd_pe1c; xpd_pe1c.trigger_read()"
+  - python -c "from xpdsim import xpd_pe1c; xpd_pe1c.get()"
   - python -c "from xpdacq.tests.conftest import *"
   - git clean -xfd
 

--- a/news/news.rst
+++ b/news/news.rst
@@ -4,7 +4,10 @@
 
 **Changed:** None
 
-**Deprecated:** None
+**Deprecated:** 
+
+* Remove static mask injection. Mask is now handled by the analysis
+  pipeline live.
 
 **Removed:** None
 

--- a/xpdacq/999-load.py
+++ b/xpdacq/999-load.py
@@ -20,19 +20,17 @@ from xpdacq.xpdacq_conf import (glbl_dict, configure_device,
 
 # configure experiment device being used in current version
 if glbl_dict['is_simulation']:
-    from xpdacq.simulation import xpd_pe1c, db, cs700, shctl1
-
-    configure_device(area_det=xpd_pe1c, shutter=shctl1,
-                     temp_controller=cs700, db=db)
+    from xpdacq.simulation import (xpd_pe1c, db, cs700, shctl1,
+                                   ring_current)
+    pe1c = xpd_pe1c # alias
 else:
     # FIXME: create synthetic ring current object in fullness of time
     from ophyd import EpicsSignalRO
-
     ring_current = EpicsSignalRO('SR:OPS-BI{DCCT:1}I:Real-I',
                                  name='ring_current')
-    configure_device(area_det=pe1c, shutter=shctl1,
-                     temp_controller=cs700, db=db,
-                     ring_current=ring_current)
+configure_device(area_det=pe1c, shutter=shctl1,
+                 temp_controller=cs700, db=db,
+                 ring_current=ring_current)
 
 # cache previous glbl state
 reload_glbl_dict = _reload_glbl()

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -162,7 +162,7 @@ def ct(dets, exposure):
                         'sp_uid': str(uuid.uuid4()),
                         'sp_plan_name': 'ct'})
     plan = bp.count([area_det], md=_md)
-    plan = bp.subs_wrapper(plan, LiveTable([area_det]))
+    plan = bp.subs_wrapper(plan, LiveTable([]))
     yield from plan
 
 
@@ -245,7 +245,7 @@ def Tramp(dets, exposure, Tstart, Tstop, Tstep, *,
     plan = bp.scan([area_det], temp_controller, Tstart, Tstop,
                    Nsteps, per_step=per_step, md=_md)
     plan = bp.subs_wrapper(plan,
-                           LiveTable([area_det, temp_controller]))
+                           LiveTable([temp_controller]))
     yield from plan
 
 
@@ -316,7 +316,7 @@ def Tlist(dets, exposure, T_list, *, per_step=_shutter_step):
     # pass xpdacq_md to as additional md to bluesky plan
     plan = bp.list_scan([area_det], T_controller, T_list,
                         per_step=_shutter_step, md=xpdacq_md)
-    plan = bp.subs_wrapper(plan, LiveTable([area_det, T_controller]))
+    plan = bp.subs_wrapper(plan, LiveTable([T_controller]))
     yield from plan
 
 
@@ -368,7 +368,7 @@ def tseries(dets, exposure, delay, num):
                         'sp_uid': str(uuid.uuid4()),
                         'sp_plan_name': 'tseries'})
     plan = bp.count([area_det], num, delay, md=_md)
-    plan = bp.subs_wrapper(plan, LiveTable([area_det]))
+    plan = bp.subs_wrapper(plan, LiveTable([]))
     yield from plan
 
 
@@ -461,7 +461,7 @@ register_plan('ct', ct)
 register_plan('Tramp', Tramp)
 register_plan('tseries', tseries)
 register_plan('Tlist', Tlist)
-register_plan('statTramp', statTramp)
+#register_plan('statTramp', statTramp)
 
 def new_short_uid():
     return str(uuid.uuid4())[:8]

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -21,6 +21,8 @@ from collections import ChainMap, OrderedDict
 
 import numpy as np
 import bluesky.plans as bp
+import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
 from bluesky.callbacks import LiveTable
 
 from .glbl import glbl
@@ -116,12 +118,12 @@ def _shutter_step(detectors, motor, step):
     """ customized step to ensure shutter is open before
     reading at each motor point and close shutter after reading
     """
-    yield from bp.checkpoint()
-    yield from bp.abs_set(motor, step, wait=True)
-    yield from bp.abs_set(xpd_configuration['shutter'],
+    yield from bps.checkpoint()
+    yield from bps.abs_set(motor, step, wait=True)
+    yield from bps.abs_set(xpd_configuration['shutter'],
                           XPD_SHUTTER_CONF['open'], wait=True)
-    yield from bp.trigger_and_read(list(detectors) + [motor])
-    yield from bp.abs_set(xpd_configuration['shutter'],
+    yield from bps.trigger_and_read(list(detectors) + [motor])
+    yield from bps.abs_set(xpd_configuration['shutter'],
                           XPD_SHUTTER_CONF['close'], wait=True)
 
 
@@ -162,7 +164,7 @@ def ct(dets, exposure):
                         'sp_uid': str(uuid.uuid4()),
                         'sp_plan_name': 'ct'})
     plan = bp.count([area_det], md=_md)
-    plan = bp.subs_wrapper(plan, LiveTable([]))
+    plan = bpp.subs_wrapper(plan, LiveTable([]))
     yield from plan
 
 
@@ -244,8 +246,7 @@ def Tramp(dets, exposure, Tstart, Tstop, Tstep, *,
                         'sp_plan_name': 'Tramp'})
     plan = bp.scan([area_det], temp_controller, Tstart, Tstop,
                    Nsteps, per_step=per_step, md=_md)
-    plan = bp.subs_wrapper(plan,
-                           LiveTable([temp_controller]))
+    plan = bpp.subs_wrapper(plan, LiveTable([temp_controller]))
     yield from plan
 
 
@@ -316,7 +317,7 @@ def Tlist(dets, exposure, T_list, *, per_step=_shutter_step):
     # pass xpdacq_md to as additional md to bluesky plan
     plan = bp.list_scan([area_det], T_controller, T_list,
                         per_step=_shutter_step, md=xpdacq_md)
-    plan = bp.subs_wrapper(plan, LiveTable([T_controller]))
+    plan = bpp.subs_wrapper(plan, LiveTable([T_controller]))
     yield from plan
 
 
@@ -368,7 +369,7 @@ def tseries(dets, exposure, delay, num):
                         'sp_uid': str(uuid.uuid4()),
                         'sp_plan_name': 'tseries'})
     plan = bp.count([area_det], num, delay, md=_md)
-    plan = bp.subs_wrapper(plan, LiveTable([]))
+    plan = bpp.subs_wrapper(plan, LiveTable([]))
     yield from plan
 
 

--- a/xpdacq/calib.py
+++ b/xpdacq/calib.py
@@ -22,6 +22,7 @@ import numpy as np
 from IPython import get_ipython
 
 import bluesky.plans as bp
+import bluesky.preprocessors as bpp
 
 from .glbl import glbl
 from .xpdacq_conf import xpd_configuration
@@ -202,9 +203,9 @@ def _collect_img(exposure, dark_sub_bool, sample_md, tag, RE_instance,
             raise xpdAcqException('empty dSpacing from calibrant')
         sample_md.update({'dSpacing': dSpacing,
                           'detector': detector})
-        plan = bp.msg_mutator(plan, _inject_calibration_tag)
+        plan = bpp.msg_mutator(plan, _inject_calibration_tag)
     elif tag == 'mask':
-        plan = bp.msg_mutator(plan, _inject_mask_tag)
+        plan = bpp.msg_mutator(plan, _inject_mask_tag)
 
     # collect image
     uid = RE_instance(sample_md, plan)

--- a/xpdacq/calib.py
+++ b/xpdacq/calib.py
@@ -210,14 +210,14 @@ def _collect_img(exposure, dark_sub_bool, sample_md, tag, RE_instance,
     # collect image
     uid = RE_instance(sample_md, plan)
     # last one must be light
-    light_header = xpd_configuration['db'][uid[-1]]
-    dark_uid = light_header.start.get('sc_dk_field_uid')
-    dark_header = xpd_configuration['db'][dark_uid]
     db = xpd_configuration['db']
-
+    light_header = db[uid[-1]]
+    dark_uid = light_header['start'].get('sc_dk_field_uid')
+    dark_header = db[dark_uid]
     dark_img = dark_header.data(glbl['det_image_field'])
     dark_img = np.asarray(next(dark_img)).squeeze()
-
+    #dark_img = next(db.get_images(dark_header,
+    #                              glbl['det_image_field']))
     img = light_header.data(glbl['det_image_field'])
     img = np.asarray(next(img)).squeeze()
 

--- a/xpdacq/simulation.py
+++ b/xpdacq/simulation.py
@@ -13,5 +13,6 @@
 # See LICENSE.txt for license information.
 #
 ##############################################################################
-from xpdsim import simple_pe1c, xpd_pe1c, shctl1, cs700, db
+from xpdsim import (simple_pe1c, xpd_pe1c, shctl1, cs700, db,
+                    ring_current)
 pe1c = simple_pe1c # alias for test

--- a/xpdacq/tests/conftest.py
+++ b/xpdacq/tests/conftest.py
@@ -19,7 +19,6 @@ import asyncio
 import numpy as np
 
 import pytest
-
 from xpdacq.xpdacq_conf import (glbl_dict,
                                 configure_device,
                                 xpd_configuration)
@@ -34,11 +33,12 @@ from pkg_resources import resource_filename as rs_fn
 
 @pytest.fixture(scope='module')
 def db():
-    from xpdsim import db, db_path
+    from xpdsim.build_sim_db import build_sim_db
+    sim_db_dir, db = build_sim_db()
     yield db
-    if os.path.exists(db_path):
+    if os.path.exists(sim_db_dir):
         print('Flush db dir')
-        shutil.rmtree(db_path)
+        shutil.rmtree(sim_db_dir)
 
 
 @pytest.fixture(scope='module')
@@ -69,7 +69,7 @@ def bt(home_dir, db):
     yield bt
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def glbl(bt):
     from xpdacq.glbl import glbl
     yield glbl

--- a/xpdacq/tests/conftest.py
+++ b/xpdacq/tests/conftest.py
@@ -26,7 +26,9 @@ from xpdacq.xpdacq_conf import (glbl_dict,
 from xpdacq.xpdacq import CustomizedRunEngine
 from xpdacq.beamtimeSetup import _start_beamtime
 from xpdacq.utils import import_sample_info, ExceltoYaml
-from xpdsim import cs700, xpd_pe1c, simple_pe1c, shctl1, ring_current
+from xpdsim import (cs700, xpd_pe1c, simple_pe1c, shctl1, ring_current,
+                    xpd_wavelength)
+
 
 from pkg_resources import resource_filename as rs_fn
 
@@ -40,13 +42,12 @@ def db():
     #    print('Flush db dir')
     #    shutil.rmtree(sim_db_dir)
 
-
 @pytest.fixture(scope='module')
 def bt(home_dir):
     # start a beamtime
     PI_name = 'Billinge '
     saf_num = 300000
-    wavelength = 0.1812
+    wavelength = xpd_wavelength
     experimenters = [('van der Banerjee', 'S0ham', 1),
                      ('Terban ', ' Max', 2)]
     bt = _start_beamtime(PI_name, saf_num,

--- a/xpdacq/tests/conftest.py
+++ b/xpdacq/tests/conftest.py
@@ -27,15 +27,18 @@ from xpdacq.xpdacq_conf import (glbl_dict,
 from xpdacq.xpdacq import CustomizedRunEngine
 from xpdacq.beamtimeSetup import _start_beamtime
 from xpdacq.utils import import_sample_info, ExceltoYaml
-from xpdsim import cs700, xpd_pe1c, simple_pe1c, shctl1
+from xpdsim import cs700, xpd_pe1c, simple_pe1c, shctl1, ring_current
 
 from pkg_resources import resource_filename as rs_fn
 
 
 @pytest.fixture(scope='module')
 def db():
-    from xpdsim import db
+    from xpdsim import db, db_path
     yield db
+    if os.path.exists(db_path):
+        print('Flush db dir')
+        shutil.rmtree(db_path)
 
 
 @pytest.fixture(scope='module')
@@ -61,7 +64,8 @@ def bt(home_dir, db):
     #pe1c = xpd_pe1c 
     pe1c = simple_pe1c
     configure_device(db=db, shutter=shctl1,
-                     area_det=pe1c, temp_controller=cs700)
+                     area_det=pe1c, temp_controller=cs700,
+                     ring_current=ring_current)
     yield bt
 
 

--- a/xpdacq/tests/conftest.py
+++ b/xpdacq/tests/conftest.py
@@ -75,7 +75,7 @@ def glbl(bt):
     yield glbl
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def fresh_xrun(bt):
     # create xrun
     xrun = CustomizedRunEngine(None)

--- a/xpdacq/tests/test_run_calib.py
+++ b/xpdacq/tests/test_run_calib.py
@@ -158,13 +158,14 @@ def test_mask_md(fresh_xrun, exp_hash_uid, glbl, db):
     assert all(v == hdr.start[k] for k, v in sample_md.items())
     assert hdr.start['mask_server_uid'] == exp_hash_uid
     assert hdr.start['mask_client_uid'] == hdr.start['mask_server_uid']
+    # Note: sparse mask injection has been deprecated
     # production run
-    mask = np.load(glbl['mask_path'])
-    reload_sparse_mask = compress_mask(mask)
-    xrun(0, 0)
-    hdr = db[-1]
-    assert hdr.start['mask_client_uid'] == exp_hash_uid
-    assert reload_sparse_mask == hdr.start['mask']
+    #mask = np.load(glbl['mask_path'])
+    #reload_sparse_mask = compress_mask(mask)
+    #xrun(0, 0)
+    #hdr = db[-1]
+    #assert hdr.start['mask_client_uid'] == exp_hash_uid
+    #assert reload_sparse_mask == hdr.start['mask']
     # update hash uid
     new_hash = update_experiment_hash_uid()
     # production run first

--- a/xpdacq/tests/test_run_calib.py
+++ b/xpdacq/tests/test_run_calib.py
@@ -55,6 +55,7 @@ def test_configure_sample_info_md(sample_name, phase_info, tag, sample_md):
 
 def test_calib_md(fresh_xrun, exp_hash_uid, glbl, db):
     xrun = fresh_xrun
+    glbl['dk_window'] = 0.1
     # calib run
     sample_md = _sample_name_phase_info_configuration(None, None, 'calib')
     calibrant = os.path.join(glbl['usrAnalysis_dir'], 'Ni24.D')

--- a/xpdacq/tests/test_run_calib.py
+++ b/xpdacq/tests/test_run_calib.py
@@ -55,7 +55,6 @@ def test_configure_sample_info_md(sample_name, phase_info, tag, sample_md):
 
 def test_calib_md(fresh_xrun, exp_hash_uid, glbl, db):
     xrun = fresh_xrun
-    glbl['dk_window'] = 0.1
     # calib run
     sample_md = _sample_name_phase_info_configuration(None, None, 'calib')
     calibrant = os.path.join(glbl['usrAnalysis_dir'], 'Ni24.D')
@@ -142,7 +141,7 @@ def test_load_calibrant(fresh_xrun, bt):
     # clean
     xrun.unsubscribe(t)
 
-@pytest.mark.skip('pipeline build mask live')
+@pytest.mark.skip('pipeline builds mask live')
 def test_mask_md(fresh_xrun, exp_hash_uid, glbl, db):
     xrun = fresh_xrun
     # grab calib information

--- a/xpdacq/tests/test_run_calib.py
+++ b/xpdacq/tests/test_run_calib.py
@@ -3,6 +3,7 @@ import pytest
 import shutil
 import uuid
 import numpy as np
+from .conftest import xpd_pe1c, xpd_configuration
 from xpdacq.xpdacq import update_experiment_hash_uid
 from xpdacq.calib import (_collect_img, xpdAcqException,
                           _sample_name_phase_info_configuration,
@@ -141,7 +142,6 @@ def test_load_calibrant(fresh_xrun, bt):
     # clean
     xrun.unsubscribe(t)
 
-@pytest.mark.skip('pipeline builds mask live')
 def test_mask_md(fresh_xrun, exp_hash_uid, glbl, db):
     xrun = fresh_xrun
     # grab calib information
@@ -151,6 +151,8 @@ def test_mask_md(fresh_xrun, exp_hash_uid, glbl, db):
     shutil.copyfile(src, dst)
     # build mask
     xrun = fresh_xrun
+    # assign detector yields real image for maksing
+    xpd_configuration['area_det'] = xpd_pe1c
     run_mask_builder(RE_instance=xrun)
     sample_md = _sample_name_phase_info_configuration(None, None, 'mask')
     assert os.path.isfile(glbl['mask_path'])

--- a/xpdacq/tests/test_run_calib.py
+++ b/xpdacq/tests/test_run_calib.py
@@ -141,6 +141,7 @@ def test_load_calibrant(fresh_xrun, bt):
     # clean
     xrun.unsubscribe(t)
 
+@pytest.mark.skip('pipeline build mask live')
 def test_mask_md(fresh_xrun, exp_hash_uid, glbl, db):
     xrun = fresh_xrun
     # grab calib information

--- a/xpdacq/tests/test_xrun.py
+++ b/xpdacq/tests/test_xrun.py
@@ -221,7 +221,7 @@ class xrunTest(unittest.TestCase):
         self.xrun.msg_hook = msg_rv
         traj_list = [] # courtesy of bluesky test
         temp_controller = xpd_configuration['temp_controller']
-        callback = collector(temp_controller.read_attrs[0],
+        callback = collector(temp_controller.readback.name,
                              traj_list)
         self.xrun({},
                   ScanPlan(self.bt, Tramp, exp, Tstart, Tstop, Tstep),
@@ -261,7 +261,7 @@ class xrunTest(unittest.TestCase):
             msg_list.append(msg)
         traj_list = [] # courtesy of bluesky test
         temp_controller = xpd_configuration['temp_controller']
-        callback = collector(temp_controller.read_attrs[0],
+        callback = collector(temp_controller.readback.name,
                              traj_list)
         self.xrun.msg_hook = msg_rv
         self.xrun({}, ScanPlan(self.bt, Tlist, exp, T_list),
@@ -312,7 +312,7 @@ class xrunTest(unittest.TestCase):
         self.xrun({}, ScanPlan(self.bt, ct, 1))
 
         # operate at full current
-        sig = ophyd.Signal()
+        sig = ophyd.Signal(name='ring_current')
 
         def putter(val):
             sig.put(val)

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -289,13 +289,13 @@ def _inject_mask_server_uid(msg):
             # inject server uid if it's calibration run
             msg.kwargs.update({'mask_server_uid':
                                exp_hash_uid})
-        else:
-            # load mask if exists
-            compressed_mask = _auto_load_mask()
-            if compressed_mask:
-                data, indicies, indptr = compressed_mask
-                # inject compressed 
-                msg.kwargs['mask'] = (data, indicies, indptr)
+        #else:
+        #    # load mask if exists
+        #    compressed_mask = _auto_load_mask()
+        #    if compressed_mask:
+        #        data, indicies, indptr = compressed_mask
+        #        # inject compressed 
+        #        msg.kwargs['mask'] = (data, indicies, indptr)
 
     return msg
 


### PR DESCRIPTION
1. Deprecate print statement regarding inject mask inside ``xrun``, since mask is built dynamically
2. Update acq code corresponding to the API changes from bluesky 1.0

closes #455 