### PR TITLE
MNT: print statement to run_calib.

### DIFF
--- a/news/news.rst
+++ b/news/news.rst
@@ -11,6 +11,10 @@
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
+
+* Instruction in ``run_calibration``. There is a specific print statement
+  to tell the user to finish the interactive calibration process in the
+  analysis terminal.
 
 **Security:** None

--- a/news/news.rst
+++ b/news/news.rst
@@ -2,12 +2,16 @@
 
 * Added news to the repo so we can changelog better
 
-**Changed:** None
+**Changed:**
+
+* Change the filepath structure in ``glbl`` to align with the update
+  at XPD. All ``xf28id1`` -> ``xf28id2``, including hostname and
+  nfs-mount drives.
 
 **Deprecated:** 
 
 * Remove static mask injection. Mask is now handled by the analysis
-  pipeline live.
+  pipeline dynamically.
 
 **Removed:** None
 

--- a/xpdacq/calib.py
+++ b/xpdacq/calib.py
@@ -147,6 +147,14 @@ def run_calibration(exposure=5, dark_sub_bool=True,
                                     detector=detector,
                                     calibrant=calibrant
                                     )
+    print("INFO: Please navigate to the analysis terminal to complete "
+          "the interactive calibration process.\nYou may find the "
+          "the analysis terminal similar to data acquisition terminal"
+          "(current terminal) except there is information about the "
+          "analysis pipeline printed")
+    print("INFO: For a quick guide on the interactive calibration "
+          "process, please visit our web-doc at:\n"
+          "https://xpdacq.github.io/xpdAcq/usb_Running.html#calib-manual\n")
 
     if not parallel:  # backup when pipeline fails
         # get wavelength from bt


### PR DESCRIPTION
Instruct the user to look for analysis terminal and finish the interactive calibration process.

closes #456 
  