### PR TITLE
FIX: exclude hidden files from _end_beamtime

### DIFF
--- a/news/rsync.rst
+++ b/news/rsync.rst
@@ -4,13 +4,19 @@
 
 **Deprecated:**
 
-* Replace most ``shutil`` functionalities with native unix commands
+* Replace most ``shutil`` functionalities with native Unix commands
   called by ``subprocess`` to have a clear picture on the system response.
 
 **Removed:** None
 
 **Fixed:**
 
-* Add ``--timeout`` option to rsync during ``end_beamtime`` to take care of (periodic) delay in nils-ii network.
+* Add ``--timeout`` option to rsync during ``_end_beamtime`` to allow 
+  temporally disconnect.
+
+* Exclude hidden files from the ``_end_beamtime`` archival. Those files 
+  are mainly used as configurations by local applications and are less 
+  likely to be reusable even if user requests them.
+
 
 **Security:** None

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -271,7 +271,7 @@ def _tar_user_data(archive_name, root_dir=None, archive_format='tar'):
         # <remote>/<PI_last+uid>/xpdUser/....
         os.makedirs(archive_full_name, exist_ok=True)
         rv = subprocess.run(['rsync', '-av', '--timeout=60',
-                             #'--exclude=*.tif',  # not used yet
+                             '--exclude=.*',  # exclude all hidden files
                              glbl_dict['home'], archive_full_name],
                              check=True,)
     finally:

--- a/xpdacq/tests/test_beamtimeSetup.py
+++ b/xpdacq/tests/test_beamtimeSetup.py
@@ -1,9 +1,10 @@
-import unittest
 import os
-import shutil
 import yaml
-from pkg_resources import resource_filename as rs_fn
+import glob
+import shutil
+import unittest
 from time import strftime
+from pkg_resources import resource_filename as rs_fn
 
 from xpdacq.xpdacq_conf import glbl_dict
 from xpdacq.beamtime import Beamtime, ScanPlan
@@ -155,8 +156,6 @@ class NewBeamtimeTest(unittest.TestCase):
                                       test_tar_name))
         # are contents tared correctly?
         archive_test_dir = os.path.join(glbl_dict['home'], 'tar_test')
-        #os.makedirs(archive_test_dir, exist_ok=True)
-        #shutil.unpack_archive(archive_full_name + '.tar', archive_test_dir)
         content_list = os.listdir(archive_full_name)
         # is remote copy starting from xpdUser?
         assert 'xpdUser' in content_list
@@ -167,12 +166,13 @@ class NewBeamtimeTest(unittest.TestCase):
         exclude_fp_list = ['xpdUser', 'xpdConfig', 'yml',
                            'samples', 'scanplans']
         bkg_fp_list = [el for el in full_fp_list if el not in
-                exclude_fp_list] # exclude top dirs
+                exclude_fp_list]  # exclude top dirs
         remote_fp_list = os.listdir(os.path.join(archive_full_name,
                                                  'xpdUser'))
         # difference should be empty set
         assert not set(bkg_fp_list).difference(remote_fp_list)
-
+        # hidden files should be excluded from the archive
+        assert not list(glob.glob(archive_full_name+'**/.*'))
         # now test deleting directories
         _delete_home_dir_tree()
         self.assertTrue(len(os.listdir(glbl_dict['home'])) == 0)


### PR DESCRIPTION
Avoid transferring hidden files, which are mainly used as configuration by local applications, during ``_end_beamtime`` process. 