### PR TITLE
Multi sample

### DIFF
--- a/news/multi_sample.rst
+++ b/news/multi_sample.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:**
+
+* Exception for non-robot multi-sample experiments, since they could happen
+  and we do support this behavior
+
+**Fixed:** None
+
+**Security:** None

--- a/xpdacq/xpdacq.py
+++ b/xpdacq/xpdacq.py
@@ -622,9 +622,6 @@ class CustomizedRunEngine(RunEngine):
                                'global metadata')
         if robot:
             metadata_kw.update(robot=True)
-        if not robot and isinstance(sample, list):
-            raise RuntimeError('Multiple samples is not supported without'
-                               'the robot')
         # The CustomizedRunEngine knows about a Beamtime object, and it
         # interprets integers for 'sample' as indexes into the Beamtime's
         # lists of Samples from all its Experiments.


### PR DESCRIPTION
This supports multi-sample non-robot scans. This could work where there are multiple samples in a capillary, a multi-sample holder, or multi region thin films.