### PR TITLE
BUG: ScanPlan args and summary

### DIFF
--- a/news/sp_summary.rst
+++ b/news/sp_summary.rst
@@ -1,0 +1,18 @@
+**Added:** None
+
+**Changed:**
+
+* Reduce summary field of callable argument in ``ScanPlan`` with only
+  its ``__name__``. Before it use ``__repr__`` which includes hash and
+  special characters that is prone to generate illegal filename for yaml.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``per_step`` argument in ``Tlist``. Before this argument is always
+  overridden by default.
+
+**Security:** None

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -864,8 +864,10 @@ class ScanPlan(ValidatedDictLike, YamlChainMap):
         complete_kwargs = bound_arguments.arguments
         # remove place holder for [pe1c]
         complete_kwargs.popitem(False)
-        # remove callable, per_step, callable is not serializable
-        complete_kwargs.pop('per_step', complete_kwargs)
+        # replace callable objects, with its func name
+        for k, v in complete_kwargs.items():
+            if callable(v):
+                complete_kwargs[k] = v.__name__
         return complete_kwargs
 
     def factory(self):

--- a/xpdacq/beamtime.py
+++ b/xpdacq/beamtime.py
@@ -334,7 +334,7 @@ def Tlist(dets, exposure, T_list, *, per_step=_shutter_step):
                  }
     # pass xpdacq_md to as additional md to bluesky plan
     plan = bp.list_scan([area_det], T_controller, T_list,
-                        per_step=_shutter_step, md=xpdacq_md)
+                        per_step=per_step, md=xpdacq_md)
     plan = bpp.subs_wrapper(plan, LiveTable([T_controller]))
     yield from plan
 
@@ -864,6 +864,8 @@ class ScanPlan(ValidatedDictLike, YamlChainMap):
         complete_kwargs = bound_arguments.arguments
         # remove place holder for [pe1c]
         complete_kwargs.popitem(False)
+        # remove callable, per_step, callable is not serializable
+        complete_kwargs.pop('per_step', complete_kwargs)
         return complete_kwargs
 
     def factory(self):


### PR DESCRIPTION
1. Fix incorrect `per_step` passed inside `Tlist`. We have ignored user input til now

2. Replace the summary of callable objects with its `__name__`. Currently, we include both `name` and `hash` in the summary which is prone to generate illegal yaml filename.
