### PR TITLE
REF: end_beamtime

### DIFF
--- a/news/ref_endbeamtime.rst
+++ b/news/ref_endbeamtime.rst
@@ -1,0 +1,16 @@
+**Added:** None
+
+**Changed:**
+
+* `endbeamtime` process renames the local `xpdUser` to
+  `xpdUser_<archive_name>` first before archiving and transferring 
+  file to remote location. This is to make sure the next beamtime 
+  will not be blocked by the backup process of last beamtime.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xpdacq/beamtimeSetup.py
+++ b/xpdacq/beamtimeSetup.py
@@ -248,7 +248,7 @@ def _end_beamtime(base_dir=None, archive_dir=None, bto=None, usr_confirm="y"):
     # confirm archive
     _confirm_archive(archive_full_name)
     # flush
-    _delete_archive_dir_tree(local_archive_name)
+    _delete_local_archive(local_archive_name)
     # delete bt
     del ips.ns_table["user_global"]["bt"]
 
@@ -355,7 +355,7 @@ def _confirm_archive(archive_f_name):
         )
 
 
-def _delete_archive_dir_tree(dir_to_flush):
+def _delete_local_archive(dir_to_flush):
     while os.path.isdir(dir_to_flush):
         try:
             rv = subprocess.run(["rm", "-r", dir_to_flush], check=True)

--- a/xpdacq/tests/test_beamtimeSetup.py
+++ b/xpdacq/tests/test_beamtimeSetup.py
@@ -10,7 +10,7 @@ from xpdacq.xpdacq_conf import glbl_dict
 from xpdacq.beamtime import Beamtime, ScanPlan
 import xpdacq.beamtimeSetup as bts
 from xpdacq.beamtimeSetup import (_start_beamtime, _end_beamtime,
-                                  _delete_archive_dir_tree, _make_clean_env,
+                                  _delete_local_archive, _make_clean_env,
                                   _clean_info, _load_bt, _load_bt_info,
                                   _tar_user_data, EXPO_LIST)
 from xpdacq.utils import (export_userScriptsEtc, import_userScriptsEtc)
@@ -198,7 +198,7 @@ class NewBeamtimeTest(unittest.TestCase):
         # hidden files should be excluded from the archive
         assert not list(glob.glob(archive_full_name + "**/.*"))
         # now test deleting directories
-        _delete_archive_dir_tree(local_archive_name)
+        _delete_local_archive(local_archive_name)
         self.assertFalse(os.path.isdir(local_archive_name))
 
     def test_import_userScript_Etc(self):


### PR DESCRIPTION
Refactor `end_beamtime` process to avoid the bottleneck at file transfer within NSLS-II network.

Detailed discussion and use case is located at

https://github.com/xpdAcq/mission-control/issues/135

cc: @dooryhee @sghose @adelezh 