### PR TITLE
DOC: scanplan autodoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ docs/_build
 
 # Rever
 rever/
+
+# pytest cache
+.pytest_cache/

--- a/docs/templates/api_doc.rst
+++ b/docs/templates/api_doc.rst
@@ -16,3 +16,13 @@ xrun API Documentation
 .. autoclass:: xpdacq.xpdacq.CustomizedRunEngine
 
    .. automethod:: xpdacq.xpdacq.CustomizedRunEngine.__call__
+
+.. _ScanPlan_api:
+
+ScanPlan API Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: xpdacq.beamtime.ct
+.. autofunction:: xpdacq.beamtime.Tramp
+.. autofunction:: xpdacq.beamtime.Tlist
+.. autofunction:: xpdacq.beamtime.tseries

--- a/news/scanplan_api.rst
+++ b/news/scanplan_api.rst
@@ -1,0 +1,13 @@
+**Added:** 
+
+* ScanPlan API doc in https://xpdacq.github.io/xpdAcq/api_doc.html
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Include sphinx autodoc of `ScanPlan`.

The doc will be rendered from docstring and look like this in html:

![image](https://user-images.githubusercontent.com/15218640/48146377-d3b0b800-e282-11e8-98ae-72d08afd3fa2.png)
